### PR TITLE
Fix EnumWrappers referencing a changed packet

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
@@ -73,7 +73,7 @@ public abstract class EnumWrappers {
 		PROTOCOL_CLASS = getEnum(PacketType.Handshake.Client.SET_PROTOCOL.getPacketClass(), 0);
 		CLIENT_COMMAND_CLASS = getEnum(PacketType.Play.Client.CLIENT_COMMAND.getPacketClass(), 0);
 		CHAT_VISIBILITY_CLASS = getEnum(PacketType.Play.Client.SETTINGS.getPacketClass(), 0);
-		DIFFICULTY_CLASS = getEnum(PacketType.Play.Client.SETTINGS.getPacketClass(), 1);
+		DIFFICULTY_CLASS = getEnum(PacketType.Play.Server.LOGIN.getPacketClass(), 1);
 		ENTITY_USE_ACTION_CLASS = getEnum(PacketType.Play.Client.USE_ENTITY.getPacketClass(), 0);
 		GAMEMODE_CLASS = getEnum(PacketType.Play.Server.LOGIN.getPacketClass(), 0);
 		


### PR DESCRIPTION
This fixes the initialization of the enum wrappers that is causing exceptions like this right now:

```
[20:27:43 ERROR]: [ServerListPlus] Unhandled exception occured in onPacketReceiving(PacketEvent) for ServerListPlus
java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
    at java.util.ArrayList.rangeCheck(ArrayList.java:653) ~[?:1.8.0_25]
    at java.util.ArrayList.get(ArrayList.java:429) ~[?:1.8.0_25]
    at com.comphenix.protocol.wrappers.EnumWrappers.getEnum(EnumWrappers.java:100) ~[ProtocolLib.jar:?]
    at com.comphenix.protocol.wrappers.EnumWrappers.initialize(EnumWrappers.java:76) ~[ProtocolLib.jar:?]
    at com.comphenix.protocol.wrappers.EnumWrappers.getProtocolClass(EnumWrappers.java:113) ~[ProtocolLib.jar:?]
    at com.comphenix.protocol.events.PacketContainer.getProtocols(PacketContainer.java:589) ~[ProtocolLib.jar:?]
    at net.minecrell.serverlistplus.bukkit.handlers.ProtocolLibHandler$StatusPacketListener.onPacketReceiving(ProtocolLibHandler.java:60) ~[ServerListPlusUniversal-3.3.2.jar:?]
    at com.comphenix.protocol.injector.SortedPacketListenerList.invokeReceivingListener(SortedPacketListenerList.java:114) [ProtocolLib.jar:?]
    at com.comphenix.protocol.injector.SortedPacketListenerList.invokePacketRecieving(SortedPacketListenerList.java:67) [ProtocolLib.jar:?]
    at com.comphenix.protocol.injector.PacketFilterManager.handlePacket(PacketFilterManager.java:636) [ProtocolLib.jar:?]
    at com.comphenix.protocol.injector.PacketFilterManager.invokePacketRecieving(PacketFilterManager.java:603) [ProtocolLib.jar:?]
    at com.comphenix.protocol.injector.netty.NettyProtocolInjector.packetReceived(NettyProtocolInjector.java:300) [ProtocolLib.jar:?]
    at com.comphenix.protocol.injector.netty.NettyProtocolInjector.onPacketReceiving(NettyProtocolInjector.java:266) [ProtocolLib.jar:?]
    at com.comphenix.protocol.injector.netty.ChannelInjector.decode(ChannelInjector.java:501) [ProtocolLib.jar:?]
    at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:241) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:149) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:332) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:318) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at com.comphenix.protocol.injector.netty.ChannelInjector$4.channelRead(ChannelInjector.java:240) [ProtocolLib.jar:?]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:332) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:318) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:163) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:332) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:318) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at net.minecraft.server.v1_8_R1.LegacyPingHandler.channelRead(SourceFile:94) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:332) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:318) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.handler.timeout.ReadTimeoutHandler.channelRead(ReadTimeoutHandler.java:150) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:332) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:318) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:787) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:125) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:507) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:464) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:378) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:350) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116) [spigot-1.8-R0.1-SNAPSHOT.jar:git-Spigot-"0eb50bc"]
    at java.lang.Thread.run(Thread.java:745) [?:1.8.0_25]
[20:27:43 ERROR]: Parameters: 
  net.minecraft.server.v1_8_R1.PacketHandshakingInSetProtocol@2c47a623[
    a=47
    b=localhost
    c=25565
    d=STATUS
  ]
```

This happens because the client settings packet no longer contains the difficulty. We can get the difficulty enum from the server login packet instead.
