### PR TITLE
Fix PlayerInfoData constructor

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/PlayerInfoData.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/PlayerInfoData.java
@@ -95,8 +95,9 @@ public class PlayerInfoData {
 					StructureModifier<Integer> ints = modifier.withType(int.class);
 					int ping = ints.read(0);
 
-					StructureModifier<PacketContainer> containers = modifier.withType(PacketContainer.class);
-					PacketContainer container = containers.read(0);
+					StructureModifier<Object> packets = modifier.withType(
+							MinecraftReflection.getMinecraftClass("PacketPlayOutPlayerInfo"));
+					Object packet = packets.read(0);
 
 					StructureModifier<NativeGameMode> gameModes = modifier.withType(
 							EnumWrappers.getGameModeClass(), EnumWrappers.getGameModeConverter());
@@ -110,7 +111,7 @@ public class PlayerInfoData {
 							MinecraftReflection.getIChatBaseComponentClass(), BukkitConverters.getWrappedChatComponentConverter());
 					WrappedChatComponent displayName = displayNames.read(0);
 					
-					return new PlayerInfoData(container, gameMode, ping, gameProfile, displayName);
+					return new PlayerInfoData(PacketContainer.fromPacket(packet), gameMode, ping, gameProfile, displayName);
 				}
 
 				// Otherwise, return NULL


### PR DESCRIPTION
According to the stacktrace of a friend's server (https://gist.github.com/cn0/a0dca5f72d496b4030d1), I looked into the class and found out that the class was missing 1 field and the constructor was in the wrong order, too.
