### PR TITLE
Fix NPE when writing PlayerInfoData to packet

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/PlayerInfoData.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/PlayerInfoData.java
@@ -80,7 +80,7 @@ public class PlayerInfoData {
 							specific.profile.handle,
 							specific.ping,
 							EnumWrappers.getGameModeConverter().getGeneric(EnumWrappers.getGameModeClass(), specific.gameMode),
-							specific.displayName.handle
+							specific.displayName != null ? specific.displayName.handle : null
 					);
 					return result;
 				} catch (Exception e) {


### PR DESCRIPTION
By default, the listName field in EntityPlayer is null. As the WrappedChatComponent ignores null values (which in itself is completely fine), the field will be null when you read one while the EntityPlayer has no listName. When you try to write one, however, the converter directly accesses the handle from the WrappedChatComponent. This means you will be trying to access the handle of null when you don't explicitly set the displayName in such a packet.