### PR TITLE
Implement AnnotatedElement contract in MethodInfo

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/reflect/MethodInfo.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/reflect/MethodInfo.java
@@ -1,5 +1,6 @@
 package com.comphenix.protocol.reflect;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.Member;
@@ -24,6 +25,18 @@ public abstract class MethodInfo implements GenericDeclaration, Member {
 	 */
 	public static MethodInfo fromMethod(final Method method) {
 		return new MethodInfo() {
+			// @Override
+			public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+				return method.getAnnotation(annotationClass);
+			}
+			// @Override
+			public Annotation[] getAnnotations() {
+				return method.getAnnotations();
+			}
+			// @Override
+			public Annotation[] getDeclaredAnnotations() {
+				return method.getDeclaredAnnotations();
+			}
 			@Override
 			public String getName() {
 				return method.getName();
@@ -104,6 +117,18 @@ public abstract class MethodInfo implements GenericDeclaration, Member {
 	 */
 	public static MethodInfo fromConstructor(final Constructor<?> constructor) {
 		return new MethodInfo() {
+			// @Override
+			public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+				return constructor.getAnnotation(annotationClass);
+			}
+			// @Override
+			public Annotation[] getAnnotations() {
+				return constructor.getAnnotations();
+			}
+			// @Override
+			public Annotation[] getDeclaredAnnotations() {
+				return constructor.getDeclaredAnnotations();
+			}
 			@Override
 			public String getName() {
 				return constructor.getName();


### PR DESCRIPTION
Since java 8, GenericDeclaration implements AnnotatedElement, adding new required methods for MethodInfo. This patch implements those methods. Java 7 compatibility should be retained (commented out the Override annotations), though that should be confirmed before merging.