### PR TITLE
Added TinyProtocol as module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <modules>
     <module>modules/API</module>
     <module>modules/ProtocolLib</module>
+    <module>modules/TinyProtocol</module>
   </modules>
 
   <description>Provides read/write access to the Minecraft protocol.</description>


### PR DESCRIPTION
Why does it not build by default?