### PR TITLE
Exact match the sendPacket method (Related #322)

### DIFF
--- a/modules/API/src/main/java/com/comphenix/protocol/utility/MinecraftMethods.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/utility/MinecraftMethods.java
@@ -16,6 +16,7 @@ import net.sf.cglib.proxy.MethodProxy;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.reflect.FuzzyReflection;
+import com.comphenix.protocol.reflect.fuzzy.FuzzyMethodContract;
 
 /**
  * Static methods for accessing Minecraft methods.
@@ -43,7 +44,13 @@ public class MinecraftMethods {
 			Class<?> serverHandlerClass = MinecraftReflection.getPlayerConnectionClass();
 
 			try {
-				sendPacketMethod = FuzzyReflection.fromClass(serverHandlerClass).getMethodByName("sendPacket.*");
+				sendPacketMethod = FuzzyReflection
+						.fromClass(serverHandlerClass)
+						.getMethod(FuzzyMethodContract.newBuilder()
+								.nameRegex("sendPacket.*")
+								.returnTypeVoid()
+								.parameterCount(1)
+								.build());
 			} catch (IllegalArgumentException e) {
 				// We can't use the method below on Netty
 				if (MinecraftReflection.isUsingNetty()) {


### PR DESCRIPTION
In 1.11.2 there are multiple sendPacket methods
`sendPacket(Packet<?>)`
`sendPacket(GenericFutureListener<? extends Future<? super Void>> , GenericFutureListener<? extends Future<? super Void>>...)`

According to the [javadoc documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredMethods--) of `getDeclaredMethods` and `getMethods` the results aren't sorted in case there are multiple methods with the same name. In this case FuzzyReflection returns only the first one. 

So this **could be** the cause for for using the wrong method and getting `IllegalArgumentException: wrong number of arguments`.