### PR TITLE
Make #deserializeLegacy() able to access private members

### DIFF
--- a/modules/API/src/main/java/com/comphenix/protocol/wrappers/ComponentParser.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/wrappers/ComponentParser.java
@@ -51,7 +51,7 @@ public class ComponentParser {
 	// Should only be needed on 1.8.
 	private static Object deserializeLegacy(Object gson, Class<?> component, StringReader str) {
 		try {
-			if(readerContructor == null){
+			if(readerConstructor == null){
 				Class<?> readerClass = Class.forName("org.bukkit.craftbukkit.libs.com.google.gson.stream.JsonReader");
 				readerConstructor = readerClass.getDeclaredConstructor(Reader.class);
 				readerConstructor.setAccessible(true);

--- a/modules/API/src/main/java/com/comphenix/protocol/wrappers/ComponentParser.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/wrappers/ComponentParser.java
@@ -27,7 +27,12 @@ import java.lang.reflect.Constructor;
  * @author dmulloy2
  */
 public class ComponentParser {
-
+	
+	private static Constructor readerConstructor;
+	private static Method setLenient;
+	private static Method getAdapter;
+	private static Method read;
+	
 	private ComponentParser() {
 	}
 
@@ -46,19 +51,21 @@ public class ComponentParser {
 	// Should only be needed on 1.8.
 	private static Object deserializeLegacy(Object gson, Class<?> component, StringReader str) {
 		try {
-			Class<?> readerClass = Class.forName("org.bukkit.craftbukkit.libs.com.google.gson.stream.JsonReader");
-			Constructor readerConstructor = readerClass.getDeclaredConstructor(Reader.class);
-			readerConstructor.setAccessible(true);
+			if(readerContructor == null){
+				Class<?> readerClass = Class.forName("org.bukkit.craftbukkit.libs.com.google.gson.stream.JsonReader");
+				readerConstructor = readerClass.getDeclaredConstructor(Reader.class);
+				readerConstructor.setAccessible(true);
+				setLenient = readerClass.getDeclaredMethod("setLenient", boolean.class);
+				setLenient.setAccessible(true);
+				getAdapter = gson.getClass().getDeclaredMethod("getAdapter", Class.class);
+				getAdapter.setAccessible(true);
+				Object adapter = getAdapter.invoke(gson, component);
+				read = adapter.getClass().getDeclaredMethod("read", readerClass);
+				read.setAccessible(true);
+			}
 			Object reader = readerConstructor.newInstance(str);
-
-			Method setLenient = readerClass.getDeclaredMethod("setLenient", boolean.class);
-			setLenient.setAccessible(true);
 			setLenient.invoke(reader, true);
-			Method getAdapter = gson.getClass().getDeclaredMethod("getAdapter", Class.class);
-			getAdapter.setAccessible(true);
 			Object adapter = getAdapter.invoke(gson, component);
-			Method read = adapter.getClass().getDeclaredMethod("read", readerClass);
-			read.setAccessible(true);
 			return read.invoke(adapter, reader);
 		} catch (ReflectiveOperationException ex) {
 			throw new RuntimeException("Failed to read JSON", ex);

--- a/modules/API/src/main/java/com/comphenix/protocol/wrappers/ComponentParser.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/wrappers/ComponentParser.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
 
 /**
  * Handles component parsing in 1.8

--- a/modules/API/src/main/java/com/comphenix/protocol/wrappers/ComponentParser.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/wrappers/ComponentParser.java
@@ -46,12 +46,18 @@ public class ComponentParser {
 	private static Object deserializeLegacy(Object gson, Class<?> component, StringReader str) {
 		try {
 			Class<?> readerClass = Class.forName("org.bukkit.craftbukkit.libs.com.google.gson.stream.JsonReader");
-			Object reader = readerClass.getConstructor(Reader.class).newInstance(str);
-			Method setLenient = readerClass.getMethod("setLenient", boolean.class);
+			Constructor readerConstructor = readerClass.getDeclaredConstructor(Reader.class);
+			readerConstructor.setAccessible(true);
+			Object reader = readerConstructor.newInstance(str);
+
+			Method setLenient = readerClass.getDeclaredMethod("setLenient", boolean.class);
+			setLenient.setAccessible(true);
 			setLenient.invoke(reader, true);
-			Method getAdapter = gson.getClass().getMethod("getAdapter", Class.class);
+			Method getAdapter = gson.getClass().getDeclaredMethod("getAdapter", Class.class);
+			getAdapter.setAccessible(true);
 			Object adapter = getAdapter.invoke(gson, component);
-			Method read = adapter.getClass().getMethod("read", readerClass);
+			Method read = adapter.getClass().getDeclaredMethod("read", readerClass);
+			read.setAccessible(true);
 			return read.invoke(adapter, reader);
 		} catch (ReflectiveOperationException ex) {
 			throw new RuntimeException("Failed to read JSON", ex);


### PR DESCRIPTION
Hello! I've been recently getting reports from users using outdated versions of MineCraft (1.8) that the my plugin doesn't work. After exploring the issue, I discovered it was caused by ProtocolLib's implementation of the `deserializeLegacy` method inside the `ComponentParser` class. For some reasons, older versions of GSON had some of the fields and methods ProtocolLib was trying to access private, making them inaccessible via the `getMethod` reflect method. However, using `getDeclaredMethod` also returns private methods, making which can be later accessed by using `setAccessible`.
I have already tested this approach and it seems to be working properly.