### PR TITLE
Also bump tested versions to 1.12.2

### DIFF
--- a/modules/API/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
@@ -39,12 +39,12 @@ public class ProtocolLibrary {
 	/**
 	 * The maximum version ProtocolLib has been tested with.
 	 */
-	public static final String MAXIMUM_MINECRAFT_VERSION = "1.12";
+	public static final String MAXIMUM_MINECRAFT_VERSION = "1.12.2";
 
 	/**
-	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.12) was released.
+	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.12.2) was released.
 	 */
-	public static final String MINECRAFT_LAST_RELEASE_DATE = "2017-06-07";
+	public static final String MINECRAFT_LAST_RELEASE_DATE = "2017-09-18";
 
 	/**
 	 * Plugins that are currently incompatible with ProtocolLib.


### PR DESCRIPTION
In your previous update, you forgot to also bump the supported versions, so I adjusted them accordingly and also set the new release-date.