### PR TITLE
Make sure getMinecraftItemStack(ItemStack) handles Material.AIR properly

### DIFF
--- a/modules/API/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -1852,7 +1852,7 @@ public class MinecraftReflection {
 	}
 
 	// ---- ItemStack conversions
-
+	private static Object itemStackAir = null;
 	private static Method asNMSCopy = null;
 	private static Method asCraftMirror = null;
 
@@ -1943,7 +1943,16 @@ public class MinecraftReflection {
 
 		if (is(getCraftItemStackClass(), specific)) {
 			// If it's already a CraftItemStack, use its handle
-			return new BukkitUnwrapper().unwrapItem(specific);
+			Object unwrapped = new BukkitUnwrapper().unwrapItem(specific);
+			if (unwrapped != null) {
+				return unwrapped;
+			} else {
+				if (itemStackAir == null) {
+					// Easiest way to get the Material.AIR ItemStack?
+					itemStackAir = getMinecraftItemStack(new ItemStack(Material.AIR));
+				}
+				return itemStackAir;
+			}
 		}
 
 		try {

--- a/modules/ProtocolLib/src/test/java/com/comphenix/protocol/utility/MinecraftReflectionTest.java
+++ b/modules/ProtocolLib/src/test/java/com/comphenix/protocol/utility/MinecraftReflectionTest.java
@@ -1,6 +1,7 @@
 package com.comphenix.protocol.utility;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,6 +21,7 @@ import net.minecraft.server.v1_12_R1.ServerPing.ServerPingPlayerSample;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Entity;
 import org.bukkit.inventory.ItemStack;
 import org.junit.AfterClass;
@@ -137,6 +139,9 @@ public class MinecraftReflectionTest {
 		ItemStack stack = new ItemStack(Material.GOLD_SWORD);
 		Object nmsStack = MinecraftReflection.getMinecraftItemStack(stack);
 		assertEquals(stack, MinecraftReflection.getBukkitItemStack(nmsStack));
+
+		// The NMS handle for CraftItemStack is null with Material.AIR, make sure it is handled correctly
+		assertNotNull(MinecraftReflection.getMinecraftItemStack(CraftItemStack.asCraftCopy(new ItemStack(Material.AIR))));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #483 and adds a test case to make sure the issue doesn't occur again.

Hopefully I followed all the code conventions, but if something needs changing, please tell me.