### PR TITLE
Properly cleanup ByteBuf in WirePacket

### DIFF
--- a/modules/API/src/main/java/com/comphenix/protocol/injector/netty/WirePacket.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/injector/netty/WirePacket.java
@@ -140,6 +140,7 @@ public class WirePacket {
 	private static byte[] getBytes(ByteBuf buffer) {
 		byte[] array = new byte[buffer.readableBytes()];
 		buffer.readBytes(array);
+		buffer.release();
 		return array;
 	}
 
@@ -158,7 +159,7 @@ public class WirePacket {
 	 * bytes from that packet
 	 * 
 	 * @param packet Existing packet
-	 * @return The ByteBuf
+	 * @return the byte array
 	 */
 	public static byte[] bytesFromPacket(PacketContainer packet) {
 		checkNotNull(packet, "packet cannot be null!");
@@ -176,6 +177,8 @@ public class WirePacket {
 		}
 
 		byte[] bytes = getBytes(buffer);
+		
+		buffer.release();
 
 		// Rewrite them to the packet to avoid issues with certain packets
 		if (packet.getType() == PacketType.Play.Server.CUSTOM_PAYLOAD

--- a/modules/API/src/main/java/com/comphenix/protocol/injector/netty/WirePacket.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/injector/netty/WirePacket.java
@@ -140,7 +140,6 @@ public class WirePacket {
 	private static byte[] getBytes(ByteBuf buffer) {
 		byte[] array = new byte[buffer.readableBytes()];
 		buffer.readBytes(array);
-		buffer.release();
 		return array;
 	}
 
@@ -197,6 +196,8 @@ public class WirePacket {
 
 			return ret;
 		}
+		
+		store.release();
 
 		return bytes;
 	}
@@ -222,8 +223,12 @@ public class WirePacket {
 		} catch (ReflectiveOperationException ex) {
 			throw new RuntimeException("Failed to serialize packet contents.", ex);
 		}
+		
+		byte[] bytes = getBytes(buffer);
+		
+		buffer.release();
 
-		return new WirePacket(id, getBytes(buffer));
+		return new WirePacket(id, bytes);
 	}
 
 	public static void writeVarInt(ByteBuf output, int i) {

--- a/modules/ProtocolLib/src/test/java/com/comphenix/protocol/injector/WirePacketTest.java
+++ b/modules/ProtocolLib/src/test/java/com/comphenix/protocol/injector/WirePacketTest.java
@@ -31,7 +31,7 @@ public class WirePacketTest {
 	public void testPackets() {
 		PacketContainer packet = new PacketContainer(PacketType.Play.Server.CHAT);
 		packet.getChatTypes().write(0, ChatType.CHAT);
-
+		
 		WirePacket wire = WirePacket.fromPacket(packet);
 		WirePacket handle = WirePacket.fromPacket(packet.getHandle());
 		assertEquals(wire, handle);


### PR DESCRIPTION
A memory leak regarding not properly releasing ByteBuf was causing netty to run out of memory and throw this exception: 

`Exception in server tick loop io.netty.util.internal.OutOfDirectMemoryError: failed to allocate 256 byte(s) of direct memory (used: 954728448, max: 954728448)`

Calling ByteBuf.release() fixes this issue.
