### PR TITLE
Fix an IllegalArgumentException on client side

### DIFF
--- a/modules/API/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -419,7 +419,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 		 */
 		public static CompressedImage fromBase64Png(String base64) {
 			try {
-                                return new EncodedCompressedImage("data:image/png;base64," + base64.replace("\n", "").replace("\r", ""));
+                               return new EncodedCompressedImage("data:image/png;base64," + base64.replace("\n", "").replace("\r", ""));
 			} catch (IllegalArgumentException e) {
 				// Remind the caller
 				throw new IllegalArgumentException("Must be a pure base64 encoded string. Cannot be an encoded text.", e);
@@ -490,7 +490,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 			if (encoded == null) {
 				final ByteBuf buffer = Unpooled.wrappedBuffer(getDataCopy());
 				encoded = "data:" + getMime() + ";base64," +
-                                                Base64.encode(buffer).toString(Charsets.UTF_8).replace("\n", "").replace("\r", "");
+                                               Base64.encode(buffer).toString(Charsets.UTF_8).replace("\n", "").replace("\r", "");
 			}
 
 			return encoded;

--- a/modules/API/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -419,7 +419,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 		 */
 		public static CompressedImage fromBase64Png(String base64) {
 			try {
-                               return new EncodedCompressedImage("data:image/png;base64," + base64.replace("\n", "").replace("\r", ""));
+				return new EncodedCompressedImage("data:image/png;base64," + base64.replace("\n", "").replace("\r", ""));
 			} catch (IllegalArgumentException e) {
 				// Remind the caller
 				throw new IllegalArgumentException("Must be a pure base64 encoded string. Cannot be an encoded text.", e);
@@ -490,7 +490,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 			if (encoded == null) {
 				final ByteBuf buffer = Unpooled.wrappedBuffer(getDataCopy());
 				encoded = "data:" + getMime() + ";base64," +
-                                               Base64.encode(buffer).toString(Charsets.UTF_8).replace("\n", "").replace("\r", "");
+						Base64.encode(buffer).toString(Charsets.UTF_8).replace("\n", "").replace("\r", "");
 			}
 
 			return encoded;

--- a/modules/API/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -419,7 +419,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 		 */
 		public static CompressedImage fromBase64Png(String base64) {
 			try {
-				return new EncodedCompressedImage("data:image/png;base64," + base64);
+                                return new EncodedCompressedImage("data:image/png;base64," + base64.replace("\n", "").replace("\r", ""));
 			} catch (IllegalArgumentException e) {
 				// Remind the caller
 				throw new IllegalArgumentException("Must be a pure base64 encoded string. Cannot be an encoded text.", e);
@@ -490,7 +490,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 			if (encoded == null) {
 				final ByteBuf buffer = Unpooled.wrappedBuffer(getDataCopy());
 				encoded = "data:" + getMime() + ";base64," +
-						Base64.encode(buffer).toString(Charsets.UTF_8);
+                                                Base64.encode(buffer).toString(Charsets.UTF_8).replace("\n", "").replace("\r", "");
 			}
 
 			return encoded;


### PR DESCRIPTION
When send a Ping packet to client, if server icon is converted via Base64, it may contains `\n` or `\r` which make client throws an exception
```
java.lang.IllegalArgumentException: Illegal base64 character a
	at java.util.Base64$Decoder.decode0(Base64.java:714) ~[?:1.8.0_74]
	at java.util.Base64$Decoder.decode(Base64.java:623) ~[?:1.8.0_74]
	at cma.g(SourceFile:212) [cma.class:?]
	at cma.a(SourceFile:144) [cma.class:?]
	at chg.a(SourceFile:35) [chg.class:?]
	at chl.a(GuiSlot.java:491) [chl.class:?]
	at chl.a(GuiSlot.java:249) [chl.class:?]
	at clx.a(SourceFile:310) [clx.class:?]
	at cty.a(EntityRenderer.java:1052) [cty.class:?]
	at cft.c(SourceFile:850) [cft.class:?]
	at cft.a(SourceFile:395) [cft.class:?]
	at net.minecraft.client.main.Main.main(SourceFile:144) [Main.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_74]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_74]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_74]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_74]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
```
This commit removes all `\n` and `\r` from result string.