### PR TITLE
Make wrapped block data work for versions below 1.13

### DIFF
--- a/modules/API/src/main/java/com/comphenix/protocol/wrappers/WrappedBlockData.java
+++ b/modules/API/src/main/java/com/comphenix/protocol/wrappers/WrappedBlockData.java
@@ -26,7 +26,6 @@ import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.utility.MinecraftVersion;
 
 import org.bukkit.Material;
-import org.bukkit.block.data.BlockData;
 
 /**
  * Represents a wrapper around IBlockData.
@@ -157,7 +156,7 @@ public abstract class WrappedBlockData extends AbstractWrapper implements Clonab
 			return new NewBlockData(FROM_LEGACY_DATA.invoke(null, material, (byte) data));
 		}
 
-		private static WrappedBlockData createNewData(BlockData data) {
+		private static WrappedBlockData createNewData(Object data) {
 			return new NewBlockData(GET_HANDLE.invoke(data));
 		}
 	}
@@ -236,8 +235,7 @@ public abstract class WrappedBlockData extends AbstractWrapper implements Clonab
 		}
 
 		private static WrappedBlockData createOldData(Material type) {
-			Object blockData = GET_BLOCK.invoke(null, type);
-			return new OldBlockData(blockData);
+			return createOldData(type, 0);
 		}
 
 		private static WrappedBlockData createOldData(Material type, int data) {
@@ -324,7 +322,7 @@ public abstract class WrappedBlockData extends AbstractWrapper implements Clonab
 	 * @param data Spigot block data
 	 * @return The new Wrapped Block Data
 	 */
-	public static WrappedBlockData createData(BlockData data) {
+	public static WrappedBlockData createData(Object data) {
 		return NewBlockData.createNewData(data);
 	}
 


### PR DESCRIPTION
This fixes a compatibility issue, with the use of BlockData not existing in the versions of Bukkit below 1.13.