### PR TITLE
Fix #661

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedBlockData.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedBlockData.java
@@ -144,7 +144,7 @@ public abstract class WrappedBlockData extends AbstractWrapper implements Clonab
 
 		@Override
 		public WrappedBlockData deepClone() {
-			return NewBlockData.createNewData(getType(), getData());
+			return new NewBlockData(new Object[]{handle}.clone()[0]);
 		}
 
 		private static WrappedBlockData createNewData(Material material) {


### PR DESCRIPTION
It seems that the `WrappedBlockData.getData()` method is returning zero for some blocks that have more information than just their material. By cloning the `IBlockData` handle (which is done [in CraftBukkit](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java#255), so I assume it's reasonable), we can make sure all data is cloned.