### PR TITLE
Use gradle wrapper instead of travis ci's inbuilt gradle version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
   - openjdk8
-script: gradle clean compileJava compileTestJava test
+script: ./gradlew clean compileJava compileTestJava test
 install: true
 notifications:
   email:


### PR DESCRIPTION
At the moment travis will always use its pre installed gradle version what leads to unpredictable build behaviour as the version can change at any time. As this project has already defined a gradle wrapper the CI should use it.