### PR TITLE
Fixed "protocollib_encoder" attempting to read non-nms packets

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
@@ -253,6 +253,11 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 					super.write(ctx, packet, promise);
 					ChannelInjector.this.finalWrite();
 				}
+
+				@Override
+				public boolean acceptOutboundMessage(Object msg) {
+					return msg instanceof WirePacket || MinecraftReflection.getPacketClass().isAssignableFrom(msg.getClass());
+				}
 			};
 
 			// Intercept recieved packets
@@ -851,6 +856,8 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 			}
 		}
 	}
+
+
 
 	/**
 	 * Execute a specific command in the channel thread.


### PR DESCRIPTION
Added an override to the encoder as such would process any non-wire packets as NMS packets. In the case of the use of different APIs, such as Artemis Packet API, such would cause a conflict and would spit out casting exceptions. It is quite easy to resolve by exclusively accepting Wire Packets and packets which are assignable to the packet class. This solves the issue and tada happy ending.

Tested on a 1.8.8 server. No issues should be noticed.