### PR TITLE
Fixed protocol injection with latest netty on minecraft 1.11 and below

### DIFF
--- a/src/main/java/com/comphenix/protocol/ProtocolLib.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLib.java
@@ -38,6 +38,7 @@ import com.comphenix.protocol.updater.Updater;
 import com.comphenix.protocol.updater.Updater.UpdateType;
 import com.comphenix.protocol.utility.ChatExtensions;
 import com.comphenix.protocol.utility.ByteBuddyFactory;
+import com.comphenix.protocol.utility.NettyVersion;
 import com.comphenix.protocol.utility.MinecraftVersion;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
@@ -170,7 +171,11 @@ public class ProtocolLib extends JavaPlugin {
 		// Print the state of the debug mode
 		if (config.isDebug()) {
 			logger.warning("Debug mode is enabled!");
+						logger.info("Detected netty version: " + NettyVersion.getVersion());
+		} else {
+			NettyVersion.getVersion(); // this will cache the version
 		}
+		
 		// And the state of the error reporter
 		if (config.isDetailedErrorReporting()) {
 			detailedReporter.setDetailedReporting(true);

--- a/src/main/java/com/comphenix/protocol/utility/NettyVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/NettyVersion.java
@@ -1,0 +1,81 @@
+import com.comphenix.protocol.ProtocolLibrary;
+import io.netty.util.Version;
+
+import java.util.Map;
+
+public class NettyVersion {
+    private final static String NETTY_ARTIFACT_ID = "netty-common";
+    private static NettyVersion version;
+
+    public static NettyVersion getVersion() {
+        if(version == null) {
+            version = detectVersion();
+        }
+        return version;
+    }
+
+    private static NettyVersion detectVersion() {
+        Map<String, Version> nettyArtifacts = Version.identify();
+        Version version = nettyArtifacts.get(NETTY_ARTIFACT_ID);
+        if(version != null) {
+            return new NettyVersion(version.artifactVersion());
+        }
+        return new NettyVersion(null);
+    }
+
+    private boolean valid = false;
+    private int major, minor, revision;
+
+    public NettyVersion(String s) {
+        if(s == null) {
+            return;
+        }
+        String[] split = s.split( "\\.");
+        try {
+            this.major = Integer.parseInt(split[0]);
+            this.minor = Integer.parseInt(split[1]);
+            this.revision = Integer.parseInt(split[2]);
+            this.valid = true;
+        } catch (Throwable t) {
+            ProtocolLibrary.getPlugin().getLogger().warning("Could not detect netty version: '" + s + "'");
+        }
+    }
+
+    @Override
+    public String toString() {
+        if(!valid) {
+            return "(invalid)";
+        }
+        return major + "." + minor + "." + revision;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof NettyVersion)) {
+            return false;
+        }
+        NettyVersion v = (NettyVersion) obj;
+        return v.major == major && v.minor == minor && v.revision == revision;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getRevision() {
+        return revision;
+    }
+
+    public boolean isValid() {
+        return this.valid;
+    }
+
+    public boolean isGreaterThan(int major, int minor, int rev) {
+        return this.major > major || this.minor > minor || this.revision > rev;
+    }
+
+}

--- a/src/main/java/com/comphenix/protocol/utility/NettyVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/NettyVersion.java
@@ -1,3 +1,5 @@
+package com.comphenix.protocol.utility;
+
 import com.comphenix.protocol.ProtocolLibrary;
 import io.netty.util.Version;
 


### PR DESCRIPTION
Fix 'Can't find NetworkManager' with a newest version of netty and lower version of Minecraft
Code from https://github.com/aadnk/ProtocolLib/pull/175/commits/2e213338ecba4383ec28ac9f48d54e3d624cf3d5

-Tested and works great