### PR TITLE
Add support for PaperMC's new Adventure API Component

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,12 @@
 			<version>${spigot.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.kyori</groupId>
+			<artifactId>adventure-text-serializer-gson</artifactId>
+			<version>4.5.0</version>
+			<scope>provided</scope>
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy -->
 		<dependency>
 			<groupId>net.bytebuddy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
 		<dependency>
 			<groupId>net.kyori</groupId>
 			<artifactId>adventure-text-serializer-gson</artifactId>
-			<version>4.5.0</version>
+			<version>4.5.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy -->

--- a/src/main/java/com/comphenix/protocol/reflect/cloning/BukkitCloner.java
+++ b/src/main/java/com/comphenix/protocol/reflect/cloning/BukkitCloner.java
@@ -31,6 +31,7 @@ import com.comphenix.protocol.wrappers.*;
 import com.comphenix.protocol.wrappers.nbt.NbtFactory;
 import com.google.common.collect.Maps;
 
+import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.chat.BaseComponent;
 
 /**
@@ -87,6 +88,11 @@ public class BukkitCloner implements Cloner {
 		try {
 			fromManual(ComponentConverter::getBaseComponentArrayClass, source ->
 					ComponentConverter.clone((BaseComponent[]) source));
+		} catch (Throwable ignored) { }
+
+		try {
+			fromManual(AdventureComponentConverter::getComponentClass, source ->
+					AdventureComponentConverter.clone((Component) source));
 		} catch (Throwable ignored) { }
 	}
 

--- a/src/main/java/com/comphenix/protocol/reflect/cloning/BukkitCloner.java
+++ b/src/main/java/com/comphenix/protocol/reflect/cloning/BukkitCloner.java
@@ -31,6 +31,7 @@ import com.comphenix.protocol.wrappers.*;
 import com.comphenix.protocol.wrappers.nbt.NbtFactory;
 import com.google.common.collect.Maps;
 
+import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.chat.BaseComponent;
 
 /**
@@ -91,7 +92,7 @@ public class BukkitCloner implements Cloner {
 
 		try {
 			fromManual(AdventureComponentConverter::getComponentClass, source ->
-					AdventureComponentConverter.clone(source));
+					AdventureComponentConverter.clone((Component) source));
 		} catch (Throwable ignored) { }
 	}
 

--- a/src/main/java/com/comphenix/protocol/reflect/cloning/BukkitCloner.java
+++ b/src/main/java/com/comphenix/protocol/reflect/cloning/BukkitCloner.java
@@ -31,7 +31,6 @@ import com.comphenix.protocol.wrappers.*;
 import com.comphenix.protocol.wrappers.nbt.NbtFactory;
 import com.google.common.collect.Maps;
 
-import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.chat.BaseComponent;
 
 /**
@@ -92,7 +91,7 @@ public class BukkitCloner implements Cloner {
 
 		try {
 			fromManual(AdventureComponentConverter::getComponentClass, source ->
-					AdventureComponentConverter.clone((Component) source));
+					AdventureComponentConverter.clone(source));
 		} catch (Throwable ignored) { }
 	}
 

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -52,7 +52,7 @@ public class AdventureComponentConverter {
   	}
 
   	public static Component clone(Object component) {
-    	GsonComponentSerializer gson = GsonComponentSerializer.gson();
+    		GsonComponentSerializer gson = GsonComponentSerializer.gson();
 		return gson.deserialize(gson.serialize((Component) component));
   	}
 }

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -23,7 +23,6 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
  * Utility class for converting between the Adventure API Component and ProtocolLib's wrapper
  * <p>
  * Note: The Adventure API Component is not included in CraftBukkit, Bukkit or Spigot and is only present in PaperMC.
- * @author LOOHP
  */
 public class AdventureComponentConverter {
 	
@@ -52,8 +51,8 @@ public class AdventureComponentConverter {
     		return Component.class;
   	}
 
-  	public static Component clone(Component component) {
-    		GsonComponentSerializer gson = GsonComponentSerializer.gson();
-		return gson.deserialize(gson.serialize(component));
+  	public static Component clone(Object component) {
+    	GsonComponentSerializer gson = GsonComponentSerializer.gson();
+		return gson.deserialize(gson.serialize((Component) component));
   	}
 }

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -52,8 +52,8 @@ public class AdventureComponentConverter {
     		return Component.class;
   	}
 
-  	public static Component clone(Object component) {
-    	GsonComponentSerializer gson = GsonComponentSerializer.gson();
-		return gson.deserialize(gson.serialize((Component) component));
+  	public static Component clone(Component component) {
+    		GsonComponentSerializer gson = GsonComponentSerializer.gson();
+		return gson.deserialize(gson.serialize(component));
   	}
 }

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -22,7 +22,7 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 /**
  * Utility class for converting between the Adventure API Component and ProtocolLib's wrapper
  * <p>
- * Note: The Adventure API Component is not included in CraftBukkit, Bukkit or Spigot and is only present in PaperMC.
+ * Note: The Adventure API Component is not included in CraftBukkit, Bukkit or Spigot and but is present in PaperMC.
  */
 public class AdventureComponentConverter {
 	

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -1,0 +1,59 @@
+/**
+ *  ProtocolLib - Bukkit server library that allows access to the Minecraft protocol.
+ *  Copyright (C) 2015 dmulloy2
+ *
+ *  This program is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU General Public License as published by the Free Software Foundation; either version 2 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with this program;
+ *  if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *  02111-1307 USA
+ */
+package com.comphenix.protocol.wrappers;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+
+/**
+ * Utility class for converting between the Adventure API Component and ProtocolLib's wrapper
+ * <p>
+ * Note: The Adventure API Component is not included in CraftBukkit, Bukkit or Spigot and is only present in PaperMC.
+ * @author LOOHP
+ */
+public class AdventureComponentConverter {
+	
+	private AdventureComponentConverter() {
+	}
+
+	/**
+	 * Converts a {@link WrappedChatComponent} into a {@link Component}
+	 * @param wrapper ProtocolLib wrapper
+	 * @return Component
+	 */
+  	public static Component fromWrapper(WrappedChatComponent wrapper) {
+    	return GsonComponentSerializer.gson().deserialize(wrapper.getJson());
+ 	}
+
+ 	/**
+	 * Converts a {@link Component} into a ProtocolLib wrapper
+	 * @param components Component
+	 * @return ProtocolLib wrapper
+	 */
+  	public static WrappedChatComponent fromComponent(Component component) {
+    	return WrappedChatComponent.fromJson(GsonComponentSerializer.gson().serialize(component));
+  	}
+
+  	public static Class<?> getComponentClass() {
+    	return Component.class;
+  	}
+
+  	public static Component clone(Component component) {
+    	GsonComponentSerializer gson = GsonComponentSerializer.gson();
+		return gson.deserialize(gson.serialize(component));
+  	}
+}

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -52,8 +52,8 @@ public class AdventureComponentConverter {
     		return Component.class;
   	}
 
-  	public static Component clone(Component component) {
-    		GsonComponentSerializer gson = GsonComponentSerializer.gson();
-		return gson.deserialize(gson.serialize(component));
+  	public static Component clone(Object component) {
+    	GsonComponentSerializer gson = GsonComponentSerializer.gson();
+		return gson.deserialize(gson.serialize((Component) component));
   	}
 }

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -52,7 +52,6 @@ public class AdventureComponentConverter {
   	}
 
   	public static Component clone(Object component) {
-    		GsonComponentSerializer gson = GsonComponentSerializer.gson();
-		return gson.deserialize(gson.serialize((Component) component));
+		return (Component) component;
   	}
 }

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -36,7 +36,7 @@ public class AdventureComponentConverter {
 	 * @return Component
 	 */
   	public static Component fromWrapper(WrappedChatComponent wrapper) {
-    	return GsonComponentSerializer.gson().deserialize(wrapper.getJson());
+    		return GsonComponentSerializer.gson().deserialize(wrapper.getJson());
  	}
 
  	/**
@@ -45,15 +45,15 @@ public class AdventureComponentConverter {
 	 * @return ProtocolLib wrapper
 	 */
   	public static WrappedChatComponent fromComponent(Component component) {
-    	return WrappedChatComponent.fromJson(GsonComponentSerializer.gson().serialize(component));
+    		return WrappedChatComponent.fromJson(GsonComponentSerializer.gson().serialize(component));
   	}
 
   	public static Class<?> getComponentClass() {
-    	return Component.class;
+    		return Component.class;
   	}
 
   	public static Component clone(Component component) {
-    	GsonComponentSerializer gson = GsonComponentSerializer.gson();
+    		GsonComponentSerializer gson = GsonComponentSerializer.gson();
 		return gson.deserialize(gson.serialize(component));
   	}
 }


### PR DESCRIPTION
Currently when trying to deepClone chat packets with a non-null `net.kyori.adventure.text.Component` field, an error saying no suitable cloner is found will be thrown.

This PR adds support to that.