### PR TITLE
Fix support for Java 16

### DIFF
--- a/src/main/java/com/comphenix/protocol/reflect/compiler/StructureCompiler.java
+++ b/src/main/java/com/comphenix/protocol/reflect/compiler/StructureCompiler.java
@@ -141,11 +141,12 @@ public final class StructureCompiler {
 	private static String COMPILED_CLASS = PACKAGE_NAME + "/CompiledStructureModifier";
 	private static String FIELD_EXCEPTION_CLASS = "com/comphenix/protocol/reflect/FieldAccessException";
 
-	// Java 60+ (16) do not allow the usage of CLassLoader#defineClass(String, byte[], int, int) anymore.
+	// On java 9+ (53.0+) CLassLoader#defineClass(String, byte[], int, int) should not be used anymore.
+	// It will throw warnings and on Java 16+ (60.0+), it does not work at all anymore.
 	private static final boolean LEGACY_CLASS_DEFINITION =
-			Float.parseFloat(System.getProperty("java.class.version")) < 60.0;
+			Float.parseFloat(System.getProperty("java.class.version")) < 53;
 	/**
-	 * The MethodHandles.Lookup object for this compiler. Only used on Java 16+.
+	 * The MethodHandles.Lookup object for this compiler. Only used when using the modern defineClass strategy.
 	 */
 	private Object lookup = null;
 


### PR DESCRIPTION
- Switched from the now-unavailable [ClassLoader::defineClass](https://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#defineClass-java.lang.String-byte:A-int-int-) method to the [MethodHandles.Lookup::defineClass](https://download.java.net/java/early_access/jdk16/docs/api/java.base/java/lang/invoke/MethodHandles.Lookup.html#defineClass(byte%5B%5D)) instead when running on Java 16.

Closes #1122, Closes #1125, Closes #1126, Closes #1127.


As noted in [JEP396](https://openjdk.java.net/jeps/396#:~:text=The%20primary%20risk%20of%20this%20proposal%20is%20that%20existing%20Java%20code%20will%20fail%20to%20run) (which is part of Java 16):

> The primary risk of this proposal is that existing Java code will fail to run. The kinds of code that will fail include, but are not limited, to:
> * Frameworks that use the protected defineClass methods of java.lang.ClassLoader in order to define new classes in existing class loaders. Such frameworks should instead use java.lang.invoke.MethodHandles.Lookup::defineClass, which has been available since JDK 9.


This PR does just that. When the server runs on Java 16, the new MethodHandles.Invoke::defineClass system will be used.

Note that this new system does not use the provided ClassLoader object anymore (the new method defines the classes in the loader of the caller). However, considering ProtocolLib only uses its own ClassLoader for the StructureCompiler anyway, this should not be a problem other than that it looks a little misleading.

To make sure this worked fine, I used LibsDisguises (6eaa42c) on Minecraft 1.16.5 with Java 15 (to ensure this PR did not accidentally break on older versions) and Java 16. 


EDIT: This PR currently only applies to Java 16+, to make sure to not break on that version. This means that this PR applies to the smallest possible group. However, that also means that this does not get rid of the "Illegal reflective access operation" message. If lower versions were to be included, then this PR would also close #1112. 
The issue is that I don't know exactly when that warning was introduced, and I've been having some difficulties getting Java 9 and 10 to work, so I cannot test it myself. However, the methods used in the PR have been available since Java 9, so it should be fine to use it starting from that version. 
Let me know what you think!