### PR TITLE
WrappedServerPing: Properly translate MotD to components for RGB colors

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedChatComponent.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedChatComponent.java
@@ -50,7 +50,7 @@ public class WrappedChatComponent extends AbstractWrapper implements ClonableWra
 		}
 
 		// Get a component from a standard Minecraft message
-		CONSTRUCT_COMPONENT = Accessors.getMethodAccessor(MinecraftReflection.getCraftChatMessage(), "fromString", String.class);
+		CONSTRUCT_COMPONENT = Accessors.getMethodAccessor(MinecraftReflection.getCraftChatMessage(), "fromString", String.class, boolean.class);
 
 		// And the component text constructor
 		CONSTRUCT_TEXT_COMPONENT = Accessors.getConstructorAccessor(MinecraftReflection.getChatComponentTextClass(), String.class);
@@ -95,6 +95,9 @@ public class WrappedChatComponent extends AbstractWrapper implements ClonableWra
 	
 	/**
 	 * Construct a wrapper around a new text chat component with the given text.
+	 * <p>
+	 * Note: {@link #fromLegacyText(String)} is preferred for text that contains
+	 * legacy formatting codes since it will translate them to the JSON equivalent.
 	 * @param text - the text of the text chat component.
 	 * @return The wrapper around the new chat component.
 	 */
@@ -111,13 +114,25 @@ public class WrappedChatComponent extends AbstractWrapper implements ClonableWra
 	 * @return The equivalent chat components.
 	 */
 	public static WrappedChatComponent[] fromChatMessage(String message) {
-		Object[] components = (Object[]) CONSTRUCT_COMPONENT.invoke(null, message);
+		Object[] components = (Object[]) CONSTRUCT_COMPONENT.invoke(null, message, false);
 		WrappedChatComponent[] result = new WrappedChatComponent[components.length];
 		
 		for (int i = 0; i < components.length; i++) {
 			result[i] = fromHandle(components[i]);
 		}
 		return result;
+	}
+
+	/**
+	 * Construct a single chat component from a standard Minecraft message
+	 * (with legacy formatting codes), preserving multiple lines.
+	 * @param message - the message.
+	 * @return The equivalent chat component.
+	 */
+	public static WrappedChatComponent fromLegacyText(String message) {
+		// With keepNewlines = true (second parameter), only one component is returned
+		Object[] components = (Object[]) CONSTRUCT_COMPONENT.invoke(null, message, true);
+		return fromHandle(components[0]);
 	}
 
 	/**

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -161,7 +161,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 	 * @param message - the message.
 	 */
 	public void setMotD(String message) {
-		setMotD(WrappedChatComponent.fromText(message));
+		setMotD(WrappedChatComponent.fromLegacyText(message));
 	}
 
 	/**


### PR DESCRIPTION
In previous Minecraft versions, using `WrappedServerPing.setMotD(String)` behaved exactly like using Bukkit's `ServerListPingEvent.setMotd(String)`.

With the addition of RGB colors in Minecraft 1.16, Spigot's `ServerListPingEvent` was patched to translate the MotD string to the
chat component equivalent to make it possible to use RGB colors in MotDs. In general, using raw legacy color codes (e.g. `§c`) within a (JSON) text component tends to cause weird issues on newer Minecraft versions, so it's better to translate them to the JSON equivalents on the server.

However, the `WrappedServerPing` implementation in ProtocolLib was never updated with the same change, which makes it behave differently from Spigot's `ServerListPingEvent` now. Using `ServerListPingEvent` RGB color codes work, using ProtocolLib they do not work.

For example:

```java
    @EventHandler
    public void onServerListPing(ServerListPingEvent event) {
        event.setMotd(ChatColor.of(new Color(121, 184, 255)) + "Hello World!\nThis is with ServerListPingEvent.");
    }
```

results in:

![Screenshot_20210502_112643](https://user-images.githubusercontent.com/3035868/116810657-5ad60280-ab45-11eb-9b9f-9cae16cfb84d.png)

but with ProtocolLib:

```java
        new PacketAdapter(this, PacketType.Status.Server.SERVER_INFO) {
            @Override
            public void onPacketReceiving(PacketEvent event) {
                final WrappedServerPing ping = event.getPacket().getServerPings().read(0);
                ping.setMotD(ChatColor.of(new Color(121, 184, 255)) + "Hello World!\nThis is with ProtocolLib.");
            }
        };
```

results in:

![Screenshot_20210502_112815](https://user-images.githubusercontent.com/3035868/116810753-dafc6800-ab45-11eb-95a3-e3d5f79dcaeb.png)

To fix this, this PR changes `WrappedServerPing.setMotD(String)` to use the same method as Spigot for translating the legacy text to the JSON/chat component equivalent. The code above now correctly results in:

![Screenshot_20210502_121753](https://user-images.githubusercontent.com/3035868/116810773-eea7ce80-ab45-11eb-847d-7c681df3fe18.png)

This allows for example ServerListPlus to use Spigot's RGB color codes (e.g. `&x&7&9&b&8&f&fHello`) without requiring any changes in ServerListPlus, e.g. with the good old ServerListPlus v3.4.8 (compiled for Minecraft 1.10 back in 2017):

```yaml
  Description:
  - |-
    &x&7&9&b&8&f&fHello World!
    This is from ServerListPlus v3.4.8.
```

![Screenshot_20210502_123823](https://user-images.githubusercontent.com/3035868/116810813-2f9fe300-ab46-11eb-9cfe-eea33dcc3a86.png)
![Screenshot_20210502_123945](https://user-images.githubusercontent.com/3035868/116810815-30387980-ab46-11eb-9718-6d0a4d3bc398.png)

The `keepNewLines` parameter of `CraftChatMessage.fromString(...)` has existed for a long time, even in Spigot 1.8 (although it was not used for `ServerListPingEvent` back then). I checked that ProtocolLib still works fine on Spigot 1.8.3 with the changes in this PR.