### PR TITLE
Update ByteBuddy dependency for Java 17 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
 		<dependency>
 			<groupId>net.bytebuddy</groupId>
 			<artifactId>byte-buddy</artifactId>
-			<version>1.10.16</version>
+			<version>1.11.0</version>
 		</dependency>
 
 		<!-- Testing dependencies -->


### PR DESCRIPTION
- Updated ByteBuddy dependency to version [1.11.0](https://github.com/raphw/byte-buddy/blob/master/release-notes.md#19-april-2021-version-1110) to add support for Java 17 (introduced in [1.10.21](https://github.com/raphw/byte-buddy/blob/master/release-notes.md#21-february-2021-version-11021)) and to take advantage of any fixes and improvements made between versions.

Just to be sure this does not break anything, I ran the unit tests using Java 8 and Java 15 (could not go higher because of other dependencies) and tried it in-game with Java 8 and Java 17-ea build 19 (on MC 1.16.5). As expected, I did not encounter any issues.

Obviously, this is a very low priority for now, but I thought it would be nice to get this out early, to ensure most people will have a compatible version of ProtocolLib (long) before Java 17's actual release in September 2021.
This assumes that no further upgrades will be required, though looking at ByteBuddy's changelog, this does not appear to have been the case for Java 15 or 16 other than for adding support for additional features (e.g. sealed classes).