### PR TITLE
Mark connectionHandler as sharable

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/ProtocolInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ProtocolInjector.java
@@ -186,6 +186,12 @@ public class ProtocolInjector implements ChannelListener {
 					channel.pipeline().addFirst(beginInitProtocol);
 					ctx.fireChannelRead(msg);
 				}
+
+				@Override
+				public boolean isSharable() {
+					// Needed if multiple objects are stored in the bootstrap list
+					return true;
+				}
 			};
 			
 			FuzzyReflection fuzzy = FuzzyReflection.fromObject(serverConnection, true);


### PR DESCRIPTION
Fixes #1170.

The reasoning for this PR is largely outlined in the above issue. As the ChannelInboundHandlerAdapter has no shared fields, a race condition cannot occur and therefore marking the class as sharable should incur no cost.

Server softwares tested with:
- 1.8.3 CraftBukkit (player connects)
- 1.8.3 Spigot (player connects)
- 1.10.2 Spigot (player connects)
- 1.12.2 Spigot (player connects; example plugin of InteractionVisualizer works on this version)
- 1.16.5 Paper (player connections and example plugin works; tested both Java 8u252 and Java 16)

Let me know if there's anything that can be done in regards to my original issue or this PR.