### PR TITLE
Remove inferences of SocketChannel presence in temporary player

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
@@ -44,7 +44,6 @@ import com.google.common.base.Preconditions;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.AttributeKey;
@@ -951,7 +950,7 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 
 		@Override
 		public Socket getSocket() {
-			return SocketAdapter.adapt((SocketChannel) injector.originalChannel);
+			return SocketAdapter.adapt(injector.originalChannel);
 		}
 
 		@Override
@@ -987,6 +986,11 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 		@Override
 		public void setUpdatedPlayer(Player updatedPlayer) {
 			injector.setPlayer(updatedPlayer);
+		}
+
+		@Override
+		public boolean isConnected() {
+			return injector.originalChannel.isActive();
 		}
 
 		ChannelInjector getChannelInjector() {

--- a/src/main/java/com/comphenix/protocol/injector/netty/SocketAdapter.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/SocketAdapter.java
@@ -43,8 +43,11 @@ public class SocketAdapter extends Socket {
         this.ch = ch;
     }
 
-    public static SocketAdapter adapt(SocketChannel ch) {
-        return new SocketAdapter(ch);
+    public static SocketAdapter adapt(Channel ch) {
+        if (!(ch instanceof SocketChannel)) {
+            return null;
+        }
+        return new SocketAdapter((SocketChannel) ch);
     }
 
     @Override

--- a/src/main/java/com/comphenix/protocol/injector/server/BukkitSocketInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/server/BukkitSocketInjector.java
@@ -80,4 +80,9 @@ public class BukkitSocketInjector implements SocketInjector {
 	public void setUpdatedPlayer(Player updatedPlayer) {
 		this.player = updatedPlayer;
 	}
+
+	@Override
+	public boolean isConnected() {
+		return player.isOnline();
+	}
 }

--- a/src/main/java/com/comphenix/protocol/injector/server/SocketInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/server/SocketInjector.java
@@ -68,4 +68,10 @@ public interface SocketInjector {
 	 * @param updatedPlayer - the real Bukkit player.
 	 */
 	public abstract void setUpdatedPlayer(Player updatedPlayer);
+
+	/**
+	 * Determines if the player is currently connected.
+	 * @return true if the player is connected.
+	 */
+	public abstract boolean isConnected();
 }

--- a/src/main/java/com/comphenix/protocol/injector/server/TemporaryPlayerFactory.java
+++ b/src/main/java/com/comphenix/protocol/injector/server/TemporaryPlayerFactory.java
@@ -157,9 +157,9 @@ public class TemporaryPlayerFactory {
 
 				// Methods that are supported in the fallback instance
 				if (methodName.equals("isOnline"))
-					return injector.getSocket() != null && injector.getSocket().isConnected();
+					return injector.isConnected();
 				else if (methodName.equals("getName"))
-					return "UNKNOWN[" + injector.getSocket().getRemoteSocketAddress() + "]";
+					return "UNKNOWN[" + injector.getAddress() + "]";
 
 				// Ignore all other methods
 				throw new UnsupportedOperationException(


### PR DESCRIPTION
To note: this is yet another compatibility change for my Geyser work, but https://github.com/PaperMC/Paper/pull/5611 will also break without these changes as Unix domain sockets don't implement SocketChannel.

The temporary player method delegation directed the isOnline and getName methods to functions that require the channel to be an instance of SocketChannel, when this won't always be the case. To solve this, this PR redirects `getSocket().getRemoteSocketAddress()` to `injector.getAddress()` which returns the same value. To determine if the player is online, a new method is created in SocketInjector to determine if a connection is online (which also returns the same value as before this commit).

The only thing I could see breaking here that would not break before this PR is anything relying on an exception being thrown. That being said, if there is a better way around this, do let me know!