### PR TITLE
Switch to GH-Workflow & use java 16 on jitpack builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: ProtocolLib full build lifecycle
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '16'
+          check-latest: true
+
+      - name: Run maven build lifecycle
+        run: mvn --batch-mode clean test package
+
+      - name: Upload plugin file
+        uses: actions/upload-artifact@v2
+        with:
+            name: ProtocolLib
+            path: target/ProtocolLib.jar

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+before_install:
+  - sdk install java 16.0.1-adpt


### PR DESCRIPTION
This pull requests adds an additional github workflow to the repository, started whenever a push or pull request is received. I was looking into the travis issue, but i can't see the build issue travis has. GitHub actions has no problems packaging & testing.

JitPack tries to build the new versions using jdk8, so a configured java version in the jitpack configuration file is nessacary. The jitpack java version file usage is documented [here](https://github.com/jitpack/jitpack.io/blob/9c724208299d90d13fc8b867896f4d0f624957b4/BUILDING.md#java-version)