### PR TITLE
Fix sdk command for jitpack builds

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,6 @@
 before_install:
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk update
+  - sdk list java
   - sdk install java 16.0.1-adopt
   - sdk use java 16.0.1-adopt

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,5 @@
 before_install:
+  - curl -s "https://get.sdkman.io" | bash
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - sdk install java 16.0.1-adpt
+  - sdk use java 16.0.1-adpt

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,5 @@
 before_install:
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - sdk update
-  - sdk list java
-  - sdk install java 16.0.1-adopt
-  - sdk use java 16.0.1-adopt
+  - sdk install java 16.0.1.hs-adpt
+  - sdk use java 16.0.1.hs-adpt

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,4 @@
 before_install:
-  - curl -s "https://get.sdkman.io" | bash
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
-  - sdk install java 16.0.1-adpt
-  - sdk use java 16.0.1-adpt
+  - sdk install java 16.0.1-adopt
+  - sdk use java 16.0.1-adopt


### PR DESCRIPTION
The jitpack documentation says something else how the sdk command works, but this is finally the correct usage of it. A test build log can be found [here](https://jitpack.io/com/github/derklaro/ProtocolLib/13ebc90/build.log)