### PR TITLE
Fix support for Minecraft versions below the bee update

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
@@ -131,11 +131,11 @@ public class PacketRegistry {
 
 		// Maps we have to occasionally check have changed
 		for (Object map : serverMaps.values()) {
-			REGISTER.addContainer(new MapContainer(map));
+			result.addContainer(new MapContainer(map));
 		}
 
 		for (Object map : clientMaps.values()) {
-			REGISTER.addContainer(new MapContainer(map));
+			result.addContainer(new MapContainer(map));
 		}
 
 		for (Object protocol : protocols) {


### PR DESCRIPTION
This pull request fixes support for ProtocolLib of versions below the bee update by adding the containers to the new created Register instance, not the constant, which is not yet initialized at this point.

Fixes #1274