### PR TITLE
Fix getEntityTrackers and updateEntity on 1.17

### DIFF
--- a/src/main/java/com/comphenix/protocol/utility/MinecraftFields.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftFields.java
@@ -15,15 +15,16 @@ public class MinecraftFields {
 	// Cached accessors
 	private static volatile FieldAccessor CONNECTION_ACCESSOR;
 	private static volatile FieldAccessor NETWORK_ACCESSOR;
-	
+	private static volatile FieldAccessor CONNECTION_ENTITY_ACCESSOR;
+
 	private MinecraftFields() {
 		// Not constructable
 	}
 	
 	/**
-	 * Retrieve the network mananger associated with a particular player.
+	 * Retrieve the network manager associated with a particular player.
 	 * @param player - the player.
-	 * @return The network manager, or NULL if no network manager has been asssociated yet.
+	 * @return The network manager, or NULL if no network manager has been associated yet.
 	 */
 	public static Object getNetworkManager(Player player) {
 		Object nmsPlayer = BukkitUnwrapper.getInstance().unwrapItem(player);
@@ -50,9 +51,13 @@ public class MinecraftFields {
 		Preconditions.checkNotNull(player, "player cannot be null!");
 		return getPlayerConnection(BukkitUnwrapper.getInstance().unwrapItem(player));
 	}
-	
-	// Retrieve player connection from a native instance
-	private static Object getPlayerConnection(Object nmsPlayer) {
+
+	/**
+	 * Retrieve the PlayerConnection (or NetServerHandler) associated with a player.
+	 * @param nmsPlayer - the NMS player.
+	 * @return The player connection.
+	 */
+	public static Object getPlayerConnection(Object nmsPlayer) {
 		Preconditions.checkNotNull(nmsPlayer, "nmsPlayer cannot be null!");
 
 		if (CONNECTION_ACCESSOR == null) {
@@ -60,5 +65,22 @@ public class MinecraftFields {
 			CONNECTION_ACCESSOR = Accessors.getFieldAccessor(nmsPlayer.getClass(), connectionClass, true);
 		}
 		return CONNECTION_ACCESSOR.get(nmsPlayer);
+	}
+
+	/**
+	 * Retrieves the EntityPlayer player field from a PlayerConnection.
+	 *
+	 * @param playerConnection The PlayerConnection object from which to retrieve the EntityPlayer field.
+	 * @return The value of the EntityPlayer field in the PlayerConnection.
+	 */
+	public static Object getPlayerFromConnection(Object playerConnection) {
+		Preconditions.checkNotNull(playerConnection, "playerConnection cannot be null!");
+
+		if (CONNECTION_ENTITY_ACCESSOR == null) {
+			Class<?> connectionClass = MinecraftReflection.getPlayerConnectionClass();
+			Class<?> entityPlayerClass = MinecraftReflection.getEntityPlayerClass();
+			CONNECTION_ENTITY_ACCESSOR = Accessors.getFieldAccessor(connectionClass, entityPlayerClass, true);
+		}
+		return CONNECTION_ENTITY_ACCESSOR.get(playerConnection);
 	}
 }

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -41,6 +41,7 @@ import javax.annotation.Nonnull;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Server;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import com.comphenix.protocol.PacketType;
@@ -373,6 +374,21 @@ public class MinecraftReflection {
 			return accessor.invoke(nmsObject);
 		} catch (Exception e) {
 			throw new IllegalArgumentException("Cannot get Bukkit entity from " + nmsObject, e);
+		}
+	}
+
+	/**
+	 * Retrieve the Bukkit player from a given PlayerConnection.
+	 * @param playerConnection The PlayerConnection.
+	 * @return A bukkit player.
+	 * @throws RuntimeException If we were unable to retrieve the Bukkit player.
+	 */
+	public static Player getBukkitPlayerFromConnection(Object playerConnection)
+	{
+		try {
+			return (Player) getBukkitEntity(MinecraftFields.getPlayerFromConnection(playerConnection));
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Cannot get Bukkit entity from connection " + playerConnection, e);
 		}
 	}
 


### PR DESCRIPTION
- In 1.17, EntityTrackerEntries use `ServerPlayerConnection`s instead of `EntityPlayer`s as they did before. This caused the `updateEntity` method to silently fail when removing the players from the `trackedPlayers` collection (of connections). This was resolved by retrieving the connections of the players before removing them from the list on 1.17+.
The getEntityTrackers method failed because it could not find any players for the same reason. This was resolved by retrieving the player from the connection before retrieving the Bukkit player from the EntityPlayer object when running on 1.17+.

This PR fixes dmulloy2/ProtocolLib#1340

I tested this PR on 1.16.5 and 1.17.1.