### PR TITLE
Add 1.17 long jump pose

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
@@ -384,6 +384,7 @@ public abstract class EnumWrappers {
 		SWIMMING, 
 		SPIN_ATTACK, 
 		CROUCHING,
+		LONG_JUMPING,
 		DYING;
 		
 		private final static EquivalentConverter<EntityPose> POSE_CONVERTER = EnumWrappers.getEntityPoseConverter();


### PR DESCRIPTION
Not sure if this needs a fallback or more specific error if someone tries using it on an older server, but the 1.17 added long_jumping entity pose was missing