### PR TITLE
Fix injection with Netty 4.1.69

### DIFF
--- a/src/main/java/com/comphenix/protocol/utility/NettyVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/NettyVersion.java
@@ -6,7 +6,8 @@ import io.netty.util.Version;
 import java.util.Map;
 
 public class NettyVersion {
-    private final static String NETTY_ARTIFACT_ID = "netty-common";
+    private final static String NETTY_COMMON_ID = "netty-common";
+    private final static String NETTY_ALL_ID = "netty-all";
     private static NettyVersion version;
 
     public static NettyVersion getVersion() {
@@ -18,7 +19,10 @@ public class NettyVersion {
 
     private static NettyVersion detectVersion() {
         Map<String, Version> nettyArtifacts = Version.identify();
-        Version version = nettyArtifacts.get(NETTY_ARTIFACT_ID);
+        Version version = nettyArtifacts.get(NETTY_COMMON_ID);
+        if(version == null) {
+            version = nettyArtifacts.get(NETTY_ALL_ID);
+        }
         if(version != null) {
             return new NettyVersion(version.artifactVersion());
         }


### PR DESCRIPTION
The issue was caused due to a change in the pom of netty (for dependencies)

(#Generated by netty-parent/pom.xml
#Mon, 11 Oct 2021 13:22:16 +0200

netty-all.version=4.1.69.Final
netty-all.buildDate=2021-10-11 13\:22\:16 +0200
netty-all.commitDate=2021-10-11 09\:21\:07 +0000
netty-all.shortCommitHash=34a31522f0
netty-all.longCommitHash=34a31522f0145e2d434aaea2ef8ac5ed8d1a91a0
netty-all.repoStatus=dirty)

Is not more netty-common, now is netty-all