### PR TITLE
Update to minecraft 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '16'
+          java-version: '17'
 
       - name: Run maven build lifecycle
         run: mvn --batch-mode clean test package

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 before_install:
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - sdk update
-  - sdk install java 16.0.1.hs-adpt
-  - sdk use java 16.0.1.hs-adpt
+  - sdk install java 17.0.1-tem
+  - sdk use java 17.0.1-tem

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<project.fullVersion>${project.version}</project.fullVersion>
 
 		<powermock.version>2.0.9</powermock.version>
-		<spigot.version>1.18-pre5-R0.1-SNAPSHOT</spigot.version>
+		<spigot.version>1.18-pre8-R0.1-SNAPSHOT</spigot.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<project.fullVersion>${project.version}</project.fullVersion>
 
 		<powermock.version>2.0.9</powermock.version>
-		<spigot.version>1.18-pre8-R0.1-SNAPSHOT</spigot.version>
+		<spigot.version>1.18-rc3-R0.1-SNAPSHOT</spigot.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.3.1</version>
 				<configuration>
 					<failOnError>false</failOnError>
 					<encoding>ISO-8859-1</encoding>
@@ -312,7 +312,7 @@
 		<dependency>
 			<groupId>net.kyori</groupId>
 			<artifactId>adventure-text-serializer-gson</artifactId>
-			<version>4.5.1</version>
+			<version>4.9.3</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy -->
@@ -332,7 +332,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>3.5.10</version>
+			<version>3.12.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<project.fullVersion>${project.version}</project.fullVersion>
 
 		<powermock.version>2.0.9</powermock.version>
-		<spigot.version>1.18-rc3-R0.1-SNAPSHOT</spigot.version>
+		<spigot.version>1.18-R0.1-SNAPSHOT</spigot.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -277,11 +277,25 @@
 	</repositories>
 
 	<dependencies>
+		<!-- Compile with the old version of Netty for backwards compat -->
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.1.70.Final</version>
+			<version>4.0.23.Final</version>
 			<scope>provided</scope>
+		</dependency>
+		<!-- since 1.18 minecraft uses new features of netty but netty is no longer bundled - make sure the new classes are available -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-common</artifactId>
+			<version>4.1.70.Final</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport</artifactId>
+			<version>4.1.70.Final</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.spigotmc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.comphenix.protocol</groupId>
 	<artifactId>ProtocolLib</artifactId>
 	<name>ProtocolLib</name>
-	<version>4.7.1-SNAPSHOT</version>
+	<version>4.7.2-SNAPSHOT</version>
 
 	<description>Provides read/write access to the Minecraft protocol.</description>
 	<url>https://github.com/dmulloy2/ProtocolLib</url>
@@ -16,8 +16,8 @@
 		<project.build.number></project.build.number>
 		<project.fullVersion>${project.version}</project.fullVersion>
 
-		<powermock.version>2.0.7</powermock.version>
-		<spigot.version>1.17.1-R0.1-SNAPSHOT</spigot.version>
+		<powermock.version>2.0.9</powermock.version>
+		<spigot.version>1.18-pre5-R0.1-SNAPSHOT</spigot.version>
 	</properties>
 
 	<build>
@@ -110,7 +110,7 @@
 					</systemProperties>
 					<!-- TODO figure out a better way to do this before Java 17 -->
 					<!-- We're currently waiting on powermock, but we may need to switch -->
-					<argLine>--illegal-access=permit</argLine>
+					<argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED</argLine>
 				</configuration>
 			</plugin>
 
@@ -277,11 +277,10 @@
 	</repositories>
 
 	<dependencies>
-		<!-- Compile with the old version of Netty for backwards compat -->
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.0.23.Final</version>
+			<version>4.1.70.Final</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -306,14 +305,14 @@
 		<dependency>
 			<groupId>net.bytebuddy</groupId>
 			<artifactId>byte-buddy</artifactId>
-			<version>1.11.0</version>
+			<version>1.12.1</version>
 		</dependency>
 
 		<!-- Testing dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/comphenix/protocol/PacketLogging.java
+++ b/src/main/java/com/comphenix/protocol/PacketLogging.java
@@ -19,6 +19,7 @@ package com.comphenix.protocol;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -206,7 +207,8 @@ public class PacketLogging implements CommandExecutor, PacketListener {
 		try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
 			if (HEX_DUMP == null) {
 				Class<?> hexDumpClass = MinecraftReflection.getLibraryClass("org.apache.commons.io.HexDump");
-				HEX_DUMP = Accessors.getMethodAccessor(FuzzyReflection.fromClass(hexDumpClass).getMethodByName("dump"));
+				HEX_DUMP = Accessors.getMethodAccessor(FuzzyReflection.fromClass(hexDumpClass)
+						.getMethodByParameters("dump", byte[].class, long.class, OutputStream.class, int.class));
 			}
 
 			HEX_DUMP.invoke(null, bytes, 0, output, 0);

--- a/src/main/java/com/comphenix/protocol/PacketLogging.java
+++ b/src/main/java/com/comphenix/protocol/PacketLogging.java
@@ -37,7 +37,6 @@ import com.comphenix.protocol.events.PacketListener;
 import com.comphenix.protocol.injector.netty.WirePacket;
 import com.google.common.base.Charsets;
 
-import org.apache.commons.io.HexDump;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;

--- a/src/main/java/com/comphenix/protocol/PacketLogging.java
+++ b/src/main/java/com/comphenix/protocol/PacketLogging.java
@@ -16,10 +16,6 @@
  */
 package com.comphenix.protocol;
 
-import com.comphenix.protocol.reflect.FuzzyReflection;
-import com.comphenix.protocol.reflect.accessors.Accessors;
-import com.comphenix.protocol.reflect.accessors.MethodAccessor;
-import com.comphenix.protocol.utility.MinecraftVersion;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -35,6 +31,10 @@ import com.comphenix.protocol.events.ListeningWhitelist;
 import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.events.PacketListener;
 import com.comphenix.protocol.injector.netty.WirePacket;
+import com.comphenix.protocol.reflect.FuzzyReflection;
+import com.comphenix.protocol.reflect.accessors.Accessors;
+import com.comphenix.protocol.reflect.accessors.MethodAccessor;
+import com.comphenix.protocol.utility.MinecraftReflection;
 import com.google.common.base.Charsets;
 
 import org.bukkit.ChatColor;
@@ -205,18 +205,7 @@ public class PacketLogging implements CommandExecutor, PacketListener {
 	private static String hexDump(byte[] bytes) throws IOException {
 		try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
 			if (HEX_DUMP == null) {
-				// since 1.18 all craft bukkit libs are no longer relocated
-				Class<?> hexDumpClass;
-				try {
-					if (MinecraftVersion.CAVES_CLIFFS_2.atOrAbove()) {
-						hexDumpClass = Class.forName("org.apache.commons.io.HexDump");
-					} else {
-						hexDumpClass = Class.forName("org.bukkit.craftbukkit.libs.org.apache.commons.io.HexDump");
-					}
-				} catch (ClassNotFoundException exception) {
-					throw new RuntimeException("Failed to find HexDump class");
-				}
-
+				Class<?> hexDumpClass = MinecraftReflection.getLibraryClass("org.apache.commons.io.HexDump");
 				HEX_DUMP = Accessors.getMethodAccessor(FuzzyReflection.fromClass(hexDumpClass).getMethodByName("dump"));
 			}
 

--- a/src/main/java/com/comphenix/protocol/PacketType.java
+++ b/src/main/java/com/comphenix/protocol/PacketType.java
@@ -137,7 +137,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 			public static final PacketType OPEN_WINDOW_HORSE =            new PacketType(PROTOCOL, SENDER, 0x1F, "OpenWindowHorse");
 			public static final PacketType INITIALIZE_BORDER =            new PacketType(PROTOCOL, SENDER, 0x20, "InitializeBorder");
 			public static final PacketType KEEP_ALIVE =                   new PacketType(PROTOCOL, SENDER, 0x21, "KeepAlive", "SPacketKeepAlive");
-			public static final PacketType MAP_CHUNK =                    new PacketType(PROTOCOL, SENDER, 0x22, "MapChunk", "SPacketChunkData");
+			public static final PacketType MAP_CHUNK =                    new PacketType(PROTOCOL, SENDER, 0x22, "MapChunk", "SPacketChunkData", "LevelChunkWithLight");
 			public static final PacketType WORLD_EVENT =                  new PacketType(PROTOCOL, SENDER, 0x23, "WorldEvent", "SPacketEffect");
 			public static final PacketType WORLD_PARTICLES =              new PacketType(PROTOCOL, SENDER, 0x24, "WorldParticles", "SPacketParticles");
 			public static final PacketType LIGHT_UPDATE =                 new PacketType(PROTOCOL, SENDER, 0x25, "LightUpdate");
@@ -190,22 +190,23 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 			public static final PacketType MOUNT =                        new PacketType(PROTOCOL, SENDER, 0x54, "Mount", "SPacketSetPassengers");
 			public static final PacketType SCOREBOARD_TEAM =              new PacketType(PROTOCOL, SENDER, 0x55, "ScoreboardTeam", "SPacketTeams");
 			public static final PacketType SCOREBOARD_SCORE =             new PacketType(PROTOCOL, SENDER, 0x56, "ScoreboardScore", "SPacketUpdateScore");
-			public static final PacketType SET_SUBTITLE_TEXT =            new PacketType(PROTOCOL, SENDER, 0x57, "SetSubtitleText");
-			public static final PacketType UPDATE_TIME =                  new PacketType(PROTOCOL, SENDER, 0x58, "UpdateTime", "SPacketTimeUpdate");
-			public static final PacketType SET_TITLE_TEXT =               new PacketType(PROTOCOL, SENDER, 0x59, "SetTitleText");
-			public static final PacketType SET_TITLES_ANIMATION =         new PacketType(PROTOCOL, SENDER, 0x5A, "SetTitlesAnimation");
-			public static final PacketType ENTITY_SOUND =                 new PacketType(PROTOCOL, SENDER, 0x5B, "EntitySound", "SPacketSoundEffect");
-			public static final PacketType NAMED_SOUND_EFFECT =           new PacketType(PROTOCOL, SENDER, 0x5C, "NamedSoundEffect");
-			public static final PacketType STOP_SOUND =                   new PacketType(PROTOCOL, SENDER, 0x5D, "StopSound");
-			public static final PacketType PLAYER_LIST_HEADER_FOOTER =    new PacketType(PROTOCOL, SENDER, 0x5E, "PlayerListHeaderFooter", "SPacketPlayerListHeaderFooter");
-			public static final PacketType NBT_QUERY =                    new PacketType(PROTOCOL, SENDER, 0x5F, "NBTQuery");
-			public static final PacketType COLLECT =                      new PacketType(PROTOCOL, SENDER, 0x60, "Collect", "SPacketCollectItem");
-			public static final PacketType ENTITY_TELEPORT =              new PacketType(PROTOCOL, SENDER, 0x61, "EntityTeleport", "SPacketEntityTeleport");
-			public static final PacketType ADVANCEMENTS =                 new PacketType(PROTOCOL, SENDER, 0x62, "Advancements", "SPacketAdvancementInfo");
-			public static final PacketType UPDATE_ATTRIBUTES =            new PacketType(PROTOCOL, SENDER, 0x63, "UpdateAttributes", "SPacketEntityProperties");
-			public static final PacketType ENTITY_EFFECT =                new PacketType(PROTOCOL, SENDER, 0x64, "EntityEffect", "SPacketEntityEffect");
-			public static final PacketType RECIPE_UPDATE =                new PacketType(PROTOCOL, SENDER, 0x65, "RecipeUpdate");
-			public static final PacketType TAGS =                         new PacketType(PROTOCOL, SENDER, 0x66, "Tags");
+			public static final PacketType UPDATE_SIMULATION_DISTANCE =   new PacketType(PROTOCOL, SENDER, 0x57, "SetSimulationDistance");
+			public static final PacketType SET_SUBTITLE_TEXT =            new PacketType(PROTOCOL, SENDER, 0x58, "SetSubtitleText");
+			public static final PacketType UPDATE_TIME =                  new PacketType(PROTOCOL, SENDER, 0x59, "UpdateTime", "SPacketTimeUpdate");
+			public static final PacketType SET_TITLE_TEXT =               new PacketType(PROTOCOL, SENDER, 0x5A, "SetTitleText");
+			public static final PacketType SET_TITLES_ANIMATION =         new PacketType(PROTOCOL, SENDER, 0x5B, "SetTitlesAnimation");
+			public static final PacketType ENTITY_SOUND =                 new PacketType(PROTOCOL, SENDER, 0x5C, "EntitySound", "SPacketSoundEffect");
+			public static final PacketType NAMED_SOUND_EFFECT =           new PacketType(PROTOCOL, SENDER, 0x5D, "NamedSoundEffect");
+			public static final PacketType STOP_SOUND =                   new PacketType(PROTOCOL, SENDER, 0x5E, "StopSound");
+			public static final PacketType PLAYER_LIST_HEADER_FOOTER =    new PacketType(PROTOCOL, SENDER, 0x5F, "PlayerListHeaderFooter", "SPacketPlayerListHeaderFooter");
+			public static final PacketType NBT_QUERY =                    new PacketType(PROTOCOL, SENDER, 0x60, "NBTQuery");
+			public static final PacketType COLLECT =                      new PacketType(PROTOCOL, SENDER, 0x61, "Collect", "SPacketCollectItem");
+			public static final PacketType ENTITY_TELEPORT =              new PacketType(PROTOCOL, SENDER, 0x62, "EntityTeleport", "SPacketEntityTeleport");
+			public static final PacketType ADVANCEMENTS =                 new PacketType(PROTOCOL, SENDER, 0x63, "Advancements", "SPacketAdvancementInfo");
+			public static final PacketType UPDATE_ATTRIBUTES =            new PacketType(PROTOCOL, SENDER, 0x64, "UpdateAttributes", "SPacketEntityProperties");
+			public static final PacketType ENTITY_EFFECT =                new PacketType(PROTOCOL, SENDER, 0x65, "EntityEffect", "SPacketEntityEffect");
+			public static final PacketType RECIPE_UPDATE =                new PacketType(PROTOCOL, SENDER, 0x66, "RecipeUpdate");
+			public static final PacketType TAGS =                         new PacketType(PROTOCOL, SENDER, 0x67, "Tags");
 
 			// ---- Removed in 1.9
 

--- a/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
@@ -41,9 +41,9 @@ public class ProtocolLibrary {
 	public static final String MAXIMUM_MINECRAFT_VERSION = "1.18";
 
 	/**
-	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.18-pre5) was released.
+	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.18) was released.
 	 */
-	public static final String MINECRAFT_LAST_RELEASE_DATE = "2021-11-19";
+	public static final String MINECRAFT_LAST_RELEASE_DATE = "2021-11-30";
 
 	/**
 	 * Plugins that are currently incompatible with ProtocolLib.

--- a/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
@@ -38,12 +38,12 @@ public class ProtocolLibrary {
 	/**
 	 * The maximum version ProtocolLib has been tested with.
 	 */
-	public static final String MAXIMUM_MINECRAFT_VERSION = "1.17.1";
+	public static final String MAXIMUM_MINECRAFT_VERSION = "1.18";
 
 	/**
-	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.17.1) was released.
+	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.18-pre5) was released.
 	 */
-	public static final String MINECRAFT_LAST_RELEASE_DATE = "2021-07-06";
+	public static final String MINECRAFT_LAST_RELEASE_DATE = "2021-11-19";
 
 	/**
 	 * Plugins that are currently incompatible with ProtocolLib.

--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
@@ -298,6 +298,11 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 
 			// Intercept all write methods
 			channelField.setValue(new ChannelProxy(originalChannel, MinecraftReflection.getPacketClass()) {
+
+				public <T> boolean hasAttr(AttributeKey<T> attributeKey) {
+					return originalChannel.hasAttr(attributeKey);
+				}
+
 				// Compatibility with Spigot 1.8
 				private final PipelineProxy pipelineProxy = new PipelineProxy(originalChannel.pipeline(), this) {
 					@Override
@@ -313,6 +318,21 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 						return super.addBefore(baseName, name, handler);
 					}
 				};
+
+				@Override
+				public ChannelId id() {
+					return originalChannel.id();
+				}
+
+				@Override
+				public long bytesBeforeUnwritable() {
+					return originalChannel.bytesBeforeUnwritable();
+				}
+
+				@Override
+				public long bytesBeforeWritable() {
+					return originalChannel.bytesBeforeWritable();
+				}
 
 				@Override
 				public ChannelPipeline pipeline() {

--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
@@ -298,7 +298,6 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 
 			// Intercept all write methods
 			channelField.setValue(new ChannelProxy(originalChannel, MinecraftReflection.getPacketClass()) {
-
 				// Compatibility with Spigot 1.8
 				private final PipelineProxy pipelineProxy = new PipelineProxy(originalChannel.pipeline(), this) {
 					@Override

--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
@@ -299,10 +299,6 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 			// Intercept all write methods
 			channelField.setValue(new ChannelProxy(originalChannel, MinecraftReflection.getPacketClass()) {
 
-				public <T> boolean hasAttr(AttributeKey<T> attributeKey) {
-					return originalChannel.hasAttr(attributeKey);
-				}
-
 				// Compatibility with Spigot 1.8
 				private final PipelineProxy pipelineProxy = new PipelineProxy(originalChannel.pipeline(), this) {
 					@Override
@@ -318,21 +314,6 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 						return super.addBefore(baseName, name, handler);
 					}
 				};
-
-				@Override
-				public ChannelId id() {
-					return originalChannel.id();
-				}
-
-				@Override
-				public long bytesBeforeUnwritable() {
-					return originalChannel.bytesBeforeUnwritable();
-				}
-
-				@Override
-				public long bytesBeforeWritable() {
-					return originalChannel.bytesBeforeWritable();
-				}
 
 				@Override
 				public ChannelPipeline pipeline() {

--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelProxy.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelProxy.java
@@ -114,11 +114,6 @@ public abstract class ChannelProxy implements Channel {
     public EventLoop eventLoop() {
 		if (loopProxy == null) {
 			loopProxy = new EventLoopProxy() {
-				@Override
-				public ChannelFuture register(ChannelPromise channelPromise) {
-					channelPromise.channel().unsafe().register(this, channelPromise);
-					return channelPromise;
-				}
 
 				@Override
 				protected EventLoop getDelegate() {

--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelProxy.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelProxy.java
@@ -115,6 +115,12 @@ public abstract class ChannelProxy implements Channel {
 		if (loopProxy == null) {
 			loopProxy = new EventLoopProxy() {
 				@Override
+				public ChannelFuture register(ChannelPromise channelPromise) {
+					channelPromise.channel().unsafe().register(this, channelPromise);
+					return channelPromise;
+				}
+
+				@Override
 				protected EventLoop getDelegate() {
 					return delegate.eventLoop();
 				}

--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelProxy.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelProxy.java
@@ -114,7 +114,6 @@ public abstract class ChannelProxy implements Channel {
     public EventLoop eventLoop() {
 		if (loopProxy == null) {
 			loopProxy = new EventLoopProxy() {
-
 				@Override
 				protected EventLoop getDelegate() {
 					return delegate.eventLoop();

--- a/src/main/java/com/comphenix/protocol/injector/netty/NettyByteBufAdapter.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/NettyByteBufAdapter.java
@@ -54,7 +54,7 @@ public class NettyByteBufAdapter extends AbstractByteBuf {
 	private static FieldAccessor READER_INDEX;
 	private static FieldAccessor WRITER_INDEX;
 	
-	private static final int CAPACITY = Short.MAX_VALUE;
+	private static final int CAPACITY = Integer.MAX_VALUE;
 	
 	private NettyByteBufAdapter(DataInputStream input, DataOutputStream output) {
 		// Just pick a figure

--- a/src/main/java/com/comphenix/protocol/injector/netty/PipelineProxy.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/PipelineProxy.java
@@ -363,7 +363,7 @@ public class PipelineProxy implements ChannelPipeline {
 	public ChannelFuture writeAndFlush(Object arg0) {
 		return pipeline.writeAndFlush(arg0);
 	}
-
+/*
 	@Override
 	public ChannelPromise newPromise() {
 		return pipeline.newPromise();
@@ -387,5 +387,5 @@ public class PipelineProxy implements ChannelPipeline {
 	@Override
 	public ChannelPromise voidPromise() {
 		return pipeline.voidPromise();
-	}
+	}*/
 }

--- a/src/main/java/com/comphenix/protocol/injector/netty/PipelineProxy.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/PipelineProxy.java
@@ -364,25 +364,28 @@ public class PipelineProxy implements ChannelPipeline {
 		return pipeline.writeAndFlush(arg0);
 	}
 
-	/* Added in Netty 4.1, seem to be unused
-	public ChannelFuture newFailedFuture(Throwable ex) {
-		return pipeline.newFailedFuture(ex);
-	}
-
-	public ChannelProgressivePromise newProgressivePromise() {
-		return pipeline.newProgressivePromise();
-	}
-
+	@Override
 	public ChannelPromise newPromise() {
 		return pipeline.newPromise();
 	}
 
+	@Override
+	public ChannelProgressivePromise newProgressivePromise() {
+		return pipeline.newProgressivePromise();
+	}
+
+	@Override
 	public ChannelFuture newSucceededFuture() {
 		return pipeline.newSucceededFuture();
 	}
 
+	@Override
+	public ChannelFuture newFailedFuture(Throwable throwable) {
+		return pipeline.newFailedFuture(throwable);
+	}
+
+	@Override
 	public ChannelPromise voidPromise() {
 		return pipeline.voidPromise();
 	}
-	*/
 }

--- a/src/main/java/com/comphenix/protocol/injector/netty/PipelineProxy.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/PipelineProxy.java
@@ -363,29 +363,26 @@ public class PipelineProxy implements ChannelPipeline {
 	public ChannelFuture writeAndFlush(Object arg0) {
 		return pipeline.writeAndFlush(arg0);
 	}
-/*
-	@Override
-	public ChannelPromise newPromise() {
-		return pipeline.newPromise();
+
+	/* Added in Netty 4.1, seem to be unused
+	public ChannelFuture newFailedFuture(Throwable ex) {
+		return pipeline.newFailedFuture(ex);
 	}
 
-	@Override
 	public ChannelProgressivePromise newProgressivePromise() {
 		return pipeline.newProgressivePromise();
 	}
 
-	@Override
+	public ChannelPromise newPromise() {
+		return pipeline.newPromise();
+	}
+
 	public ChannelFuture newSucceededFuture() {
 		return pipeline.newSucceededFuture();
 	}
 
-	@Override
-	public ChannelFuture newFailedFuture(Throwable throwable) {
-		return pipeline.newFailedFuture(throwable);
-	}
-
-	@Override
 	public ChannelPromise voidPromise() {
 		return pipeline.voidPromise();
-	}*/
+	}
+	*/
 }

--- a/src/main/java/com/comphenix/protocol/reflect/FieldUtils.java
+++ b/src/main/java/com/comphenix/protocol/reflect/FieldUtils.java
@@ -17,6 +17,7 @@ package com.comphenix.protocol.reflect;
  * limitations under the License.
  */
 
+import com.comphenix.protocol.reflect.accessors.Accessors;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
@@ -442,12 +443,8 @@ public class FieldUtils {
 		if (field == null) {
 			throw new IllegalArgumentException("The field must not be null");
 		}
-		if (forceAccess && !field.isAccessible()) {
-			field.setAccessible(true);
-		} else {
-			MemberUtils.setAccessibleWorkaround(field);
-		}
-		field.set(target, value);
+
+		Accessors.getFieldAccessor(field, forceAccess).set(target, value);
 	}
 
 	/**

--- a/src/main/java/com/comphenix/protocol/reflect/accessors/DefaultFieldAccessor.java
+++ b/src/main/java/com/comphenix/protocol/reflect/accessors/DefaultFieldAccessor.java
@@ -1,14 +1,28 @@
 package com.comphenix.protocol.reflect.accessors;
 
+import com.comphenix.protocol.ProtocolLogger;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.WrongMethodTypeException;
 import java.lang.reflect.Field;
 
 final class DefaultFieldAccessor implements FieldAccessor {
+
 	private final Field field;
-	
+
+	private MethodHandle setter;
+
 	public DefaultFieldAccessor(Field field) {
 		this.field = field;
+		// try to get a getter and setter handle for the field
+		if (UnsafeFieldAccess.hasTrustedLookup()) {
+			try {
+				setter = UnsafeFieldAccess.findSetter(field);
+			} catch (ReflectiveOperationException exception) {
+				ProtocolLogger.debug("Unable to get setter for field " + field, exception);
+			}
+		}
 	}
-	
+
 	@Override
 	public Object get(Object instance) {
 		try {
@@ -19,18 +33,25 @@ final class DefaultFieldAccessor implements FieldAccessor {
 			throw new IllegalStateException("Cannot use reflection.", e);
 		}
 	}
-	
+
 	@Override
 	public void set(Object instance, Object value) {
 		try {
-			field.set(instance, value);
-		} catch (IllegalArgumentException e) {
+			if (setter == null) {
+				field.set(instance, value);
+			} else {
+				setter.invoke(instance, value);
+			}
+		} catch (IllegalArgumentException | ClassCastException e) {
 			throw new RuntimeException("Cannot set field " + field + " to value " + value, e);
-		} catch (IllegalAccessException e) {
+		} catch (IllegalAccessException | WrongMethodTypeException e) {
 			throw new IllegalStateException("Cannot use reflection.", e);
+		} catch (Throwable ignored) {
+			// cannot happen - this might only occur when the handle targets a method
+			throw new RuntimeException("Cannot happen");
 		}
 	}
-	
+
 	@Override
 	public Field getField() {
 		return field;
@@ -43,16 +64,17 @@ final class DefaultFieldAccessor implements FieldAccessor {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		
+		}
+
 		if (obj instanceof DefaultFieldAccessor) {
 			DefaultFieldAccessor other = (DefaultFieldAccessor) obj;
 			return other.field == field;
 		}
 		return true;
 	}
-	
+
 	@Override
 	public String toString() {
 		return "DefaultFieldAccessor [field=" + field + "]";

--- a/src/main/java/com/comphenix/protocol/reflect/accessors/UnsafeFieldAccess.java
+++ b/src/main/java/com/comphenix/protocol/reflect/accessors/UnsafeFieldAccess.java
@@ -1,0 +1,48 @@
+package com.comphenix.protocol.reflect.accessors;
+
+import com.comphenix.protocol.ProtocolLogger;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.logging.Level;
+
+final class UnsafeFieldAccess {
+
+	private static final Lookup TRUSTED_LOOKUP;
+
+	static {
+		Lookup trusted = null;
+		try {
+			// get the unsafe class
+			Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+			// get the unsafe instance
+			Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe");
+			theUnsafe.setAccessible(true);
+			sun.misc.Unsafe unsafe = (sun.misc.Unsafe) theUnsafe.get(null);
+			// get the trusted lookup field
+			Field trustedLookup = Lookup.class.getDeclaredField("IMPL_LOOKUP");
+			// get access to the base and offset value of it
+			long offset = unsafe.staticFieldOffset(trustedLookup);
+			Object baseValue = unsafe.staticFieldBase(trustedLookup);
+			// get the trusted lookup instance
+			trusted = (Lookup) unsafe.getObject(baseValue, offset);
+		} catch (Exception exception) {
+			ProtocolLogger.log(Level.SEVERE, "Unable to retrieve trusted lookup", exception);
+		}
+
+		TRUSTED_LOOKUP = trusted;
+	}
+
+	public static boolean hasTrustedLookup() {
+		return TRUSTED_LOOKUP != null;
+	}
+
+	public static MethodHandle findSetter(Field field) throws ReflectiveOperationException {
+		if (Modifier.isStatic(field.getModifiers())) {
+			return TRUSTED_LOOKUP.findStaticSetter(field.getDeclaringClass(), field.getName(), field.getType());
+		} else {
+			return TRUSTED_LOOKUP.findSetter(field.getDeclaringClass(), field.getName(), field.getType());
+		}
+	}
+}

--- a/src/main/java/com/comphenix/protocol/utility/Constants.java
+++ b/src/main/java/com/comphenix/protocol/utility/Constants.java
@@ -21,10 +21,10 @@ package com.comphenix.protocol.utility;
  */
 
 public final class Constants {
-	public static final String PACKAGE_VERSION = "v1_17_R1";
+	public static final String PACKAGE_VERSION = "v1_18_R1";
 	public static final String NMS = "net.minecraft";
 	public static final String OBC = "org.bukkit.craftbukkit." + PACKAGE_VERSION;
-	public static final MinecraftVersion CURRENT_VERSION = MinecraftVersion.CAVES_CLIFFS_1;
+	public static final MinecraftVersion CURRENT_VERSION = MinecraftVersion.CAVES_CLIFFS_2;
 
 	public static void init() {
 		MinecraftReflection.setMinecraftPackage(NMS, OBC);

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftProtocolVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftProtocolVersion.java
@@ -76,6 +76,8 @@ public class MinecraftProtocolVersion {
 
 		map.put(new MinecraftVersion(1, 17, 0), 755);
 		map.put(new MinecraftVersion(1, 17, 1), 756);
+
+		map.put(new MinecraftVersion(1, 18, 0), 757);
 		return map;
 	}
 

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -2267,13 +2267,7 @@ public class MinecraftReflection {
 	}
 
 	public static Class<?> getFastUtilClass(String className) {
-		try {
-			return getMinecraftLibraryClass("it.unimi.dsi.fastutil." + className);
-		} catch (RuntimeException ex) {
-			Class<?> clazz = getMinecraftLibraryClass("org.bukkit.craftbukkit.libs.it.unimi.dsi.fastutil." + className);
-			setMinecraftLibraryClass("it.unimi.dsi.fastutil." + className, clazz);
-			return clazz;
-		}
+		return getLibraryClass("it.unimi.dsi.fastutil." + className);
 	}
 
 	public static Class<?> getInt2ObjectMapClass() {
@@ -2282,5 +2276,15 @@ public class MinecraftReflection {
 
 	public static Class<?> getIntArrayListClass() {
 		return getFastUtilClass("ints.IntArrayList");
+	}
+
+	public static Class<?> getLibraryClass(String classname) {
+		try {
+			return getMinecraftLibraryClass(classname);
+		} catch (RuntimeException ex) {
+			Class<?> clazz = getMinecraftLibraryClass("org.bukkit.craftbukkit.libs." + classname);
+			setMinecraftLibraryClass(classname, clazz);
+			return clazz;
+		}
 	}
 }

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftVersion.java
@@ -45,6 +45,11 @@ public class MinecraftVersion implements Comparable<MinecraftVersion>, Serializa
 	private static final Pattern VERSION_PATTERN = Pattern.compile(".*\\(.*MC.\\s*([a-zA-z0-9\\-.]+).*");
 
 	/**
+	 * Version 1.18 - caves and cliffs part 2
+	 */
+	public static final MinecraftVersion CAVES_CLIFFS_2 = new MinecraftVersion("1.18");
+
+	/**
 	 * Version 1.17 - caves and cliffs part 1
 	 */
 	public static final MinecraftVersion CAVES_CLIFFS_1 = new MinecraftVersion("1.17");

--- a/src/main/java/com/comphenix/protocol/utility/ZeroBuffer.java
+++ b/src/main/java/com/comphenix/protocol/utility/ZeroBuffer.java
@@ -2,14 +2,13 @@ package com.comphenix.protocol.utility;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufProcessor;
 
-import io.netty.util.ByteProcessor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
@@ -53,16 +52,6 @@ public class ZeroBuffer extends ByteBuf {
     @Override
     public boolean isDirect() {
         return false;
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return false;
-    }
-
-    @Override
-    public ByteBuf asReadOnly() {
-        return this;
     }
 
     @Override
@@ -191,17 +180,7 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public short getShortLE(int i) {
-        return 0;
-    }
-
-    @Override
     public int getUnsignedShort(int i) {
-        return 0;
-    }
-
-    @Override
-    public int getUnsignedShortLE(int i) {
         return 0;
     }
 
@@ -211,17 +190,7 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int getMediumLE(int i) {
-        return 0;
-    }
-
-    @Override
     public int getUnsignedMedium(int i) {
-        return 0;
-    }
-
-    @Override
-    public int getUnsignedMediumLE(int i) {
         return 0;
     }
 
@@ -231,27 +200,12 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int getIntLE(int i) {
-        return 0;
-    }
-
-    @Override
     public long getUnsignedInt(int i) {
         return 0;
     }
 
     @Override
-    public long getUnsignedIntLE(int i) {
-        return 0;
-    }
-
-    @Override
     public long getLong(int i) {
-        return 0;
-    }
-
-    @Override
-    public long getLongLE(int i) {
         return 0;
     }
 
@@ -311,16 +265,6 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int getBytes(int i, FileChannel fileChannel, long l, int i1) throws IOException {
-        return 0;
-    }
-
-    @Override
-    public CharSequence getCharSequence(int i, int i1, Charset charset) {
-        return null;
-    }
-
-    @Override
     public ByteBuf setBoolean(int i, boolean b) {
         return null;
     }
@@ -336,17 +280,7 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public ByteBuf setShortLE(int i, int i1) {
-        return null;
-    }
-
-    @Override
     public ByteBuf setMedium(int i, int i1) {
-        return null;
-    }
-
-    @Override
-    public ByteBuf setMediumLE(int i, int i1) {
         return null;
     }
 
@@ -356,17 +290,7 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public ByteBuf setIntLE(int i, int i1) {
-        return null;
-    }
-
-    @Override
     public ByteBuf setLong(int i, long l) {
-        return null;
-    }
-
-    @Override
-    public ByteBuf setLongLE(int i, long l) {
         return null;
     }
 
@@ -426,18 +350,8 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int setBytes(int i, FileChannel fileChannel, long l, int i1) throws IOException {
-        return 0;
-    }
-
-    @Override
     public ByteBuf setZero(int i, int i1) {
         return null;
-    }
-
-    @Override
-    public int setCharSequence(int i, CharSequence charSequence, Charset charset) {
-        return 0;
     }
 
     @Override
@@ -461,17 +375,7 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public short readShortLE() {
-        return 0;
-    }
-
-    @Override
     public int readUnsignedShort() {
-        return 0;
-    }
-
-    @Override
-    public int readUnsignedShortLE() {
         return 0;
     }
 
@@ -481,17 +385,7 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int readMediumLE() {
-        return 0;
-    }
-
-    @Override
     public int readUnsignedMedium() {
-        return 0;
-    }
-
-    @Override
-    public int readUnsignedMediumLE() {
         return 0;
     }
 
@@ -501,27 +395,12 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int readIntLE() {
-        return 0;
-    }
-
-    @Override
     public long readUnsignedInt() {
         return 0;
     }
 
     @Override
-    public long readUnsignedIntLE() {
-        return 0;
-    }
-
-    @Override
     public long readLong() {
-        return 0;
-    }
-
-    @Override
-    public long readLongLE() {
         return 0;
     }
 
@@ -547,11 +426,6 @@ public class ZeroBuffer extends ByteBuf {
 
     @Override
     public ByteBuf readSlice(int i) {
-        return null;
-    }
-
-    @Override
-    public ByteBuf readRetainedSlice(int i) {
         return null;
     }
 
@@ -596,16 +470,6 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public CharSequence readCharSequence(int i, Charset charset) {
-        return null;
-    }
-
-    @Override
-    public int readBytes(FileChannel fileChannel, long l, int i) throws IOException {
-        return 0;
-    }
-
-    @Override
     public ByteBuf skipBytes(int i) {
         return null;
     }
@@ -626,17 +490,7 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public ByteBuf writeShortLE(int i) {
-        return null;
-    }
-
-    @Override
     public ByteBuf writeMedium(int i) {
-        return null;
-    }
-
-    @Override
-    public ByteBuf writeMediumLE(int i) {
         return null;
     }
 
@@ -646,17 +500,7 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public ByteBuf writeIntLE(int i) {
-        return null;
-    }
-
-    @Override
     public ByteBuf writeLong(long l) {
-        return null;
-    }
-
-    @Override
-    public ByteBuf writeLongLE(long l) {
         return null;
     }
 
@@ -716,18 +560,8 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int writeBytes(FileChannel fileChannel, long l, int i) throws IOException {
-        return 0;
-    }
-
-    @Override
     public ByteBuf writeZero(int i) {
         return null;
-    }
-
-    @Override
-    public int writeCharSequence(CharSequence charSequence, Charset charset) {
-        return 0;
     }
 
     @Override
@@ -751,22 +585,22 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int forEachByte(ByteProcessor byteProcessor) {
+    public int forEachByte(ByteBufProcessor byteBufProcessor) {
         return 0;
     }
 
     @Override
-    public int forEachByte(int i, int i1, ByteProcessor byteProcessor) {
+    public int forEachByte(int i, int i1, ByteBufProcessor byteBufProcessor) {
         return 0;
     }
 
     @Override
-    public int forEachByteDesc(ByteProcessor byteProcessor) {
+    public int forEachByteDesc(ByteBufProcessor byteBufProcessor) {
         return 0;
     }
 
     @Override
-    public int forEachByteDesc(int i, int i1, ByteProcessor byteProcessor) {
+    public int forEachByteDesc(int i, int i1, ByteBufProcessor byteBufProcessor) {
         return 0;
     }
 
@@ -786,27 +620,12 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public ByteBuf retainedSlice() {
-        return null;
-    }
-
-    @Override
     public ByteBuf slice(int i, int i1) {
         return null;
     }
 
     @Override
-    public ByteBuf retainedSlice(int i, int i1) {
-        return null;
-    }
-
-    @Override
     public ByteBuf duplicate() {
-        return null;
-    }
-
-    @Override
-    public ByteBuf retainedDuplicate() {
         return null;
     }
 
@@ -897,16 +716,6 @@ public class ZeroBuffer extends ByteBuf {
 
     @Override
     public ByteBuf retain(int i) {
-        return null;
-    }
-
-    @Override
-    public ByteBuf touch() {
-        return null;
-    }
-
-    @Override
-    public ByteBuf touch(Object o) {
         return null;
     }
 

--- a/src/main/java/com/comphenix/protocol/utility/ZeroBuffer.java
+++ b/src/main/java/com/comphenix/protocol/utility/ZeroBuffer.java
@@ -2,13 +2,14 @@ package com.comphenix.protocol.utility;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufProcessor;
 
+import io.netty.util.ByteProcessor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
@@ -52,6 +53,16 @@ public class ZeroBuffer extends ByteBuf {
     @Override
     public boolean isDirect() {
         return false;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public ByteBuf asReadOnly() {
+        return this;
     }
 
     @Override
@@ -180,7 +191,17 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public short getShortLE(int i) {
+        return 0;
+    }
+
+    @Override
     public int getUnsignedShort(int i) {
+        return 0;
+    }
+
+    @Override
+    public int getUnsignedShortLE(int i) {
         return 0;
     }
 
@@ -190,7 +211,17 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public int getMediumLE(int i) {
+        return 0;
+    }
+
+    @Override
     public int getUnsignedMedium(int i) {
+        return 0;
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int i) {
         return 0;
     }
 
@@ -200,12 +231,27 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public int getIntLE(int i) {
+        return 0;
+    }
+
+    @Override
     public long getUnsignedInt(int i) {
         return 0;
     }
 
     @Override
+    public long getUnsignedIntLE(int i) {
+        return 0;
+    }
+
+    @Override
     public long getLong(int i) {
+        return 0;
+    }
+
+    @Override
+    public long getLongLE(int i) {
         return 0;
     }
 
@@ -265,6 +311,16 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public int getBytes(int i, FileChannel fileChannel, long l, int i1) throws IOException {
+        return 0;
+    }
+
+    @Override
+    public CharSequence getCharSequence(int i, int i1, Charset charset) {
+        return null;
+    }
+
+    @Override
     public ByteBuf setBoolean(int i, boolean b) {
         return null;
     }
@@ -280,7 +336,17 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int i, int i1) {
+        return null;
+    }
+
+    @Override
     public ByteBuf setMedium(int i, int i1) {
+        return null;
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int i, int i1) {
         return null;
     }
 
@@ -290,7 +356,17 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int i, int i1) {
+        return null;
+    }
+
+    @Override
     public ByteBuf setLong(int i, long l) {
+        return null;
+    }
+
+    @Override
+    public ByteBuf setLongLE(int i, long l) {
         return null;
     }
 
@@ -350,8 +426,18 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public int setBytes(int i, FileChannel fileChannel, long l, int i1) throws IOException {
+        return 0;
+    }
+
+    @Override
     public ByteBuf setZero(int i, int i1) {
         return null;
+    }
+
+    @Override
+    public int setCharSequence(int i, CharSequence charSequence, Charset charset) {
+        return 0;
     }
 
     @Override
@@ -375,7 +461,17 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public short readShortLE() {
+        return 0;
+    }
+
+    @Override
     public int readUnsignedShort() {
+        return 0;
+    }
+
+    @Override
+    public int readUnsignedShortLE() {
         return 0;
     }
 
@@ -385,7 +481,17 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public int readMediumLE() {
+        return 0;
+    }
+
+    @Override
     public int readUnsignedMedium() {
+        return 0;
+    }
+
+    @Override
+    public int readUnsignedMediumLE() {
         return 0;
     }
 
@@ -395,12 +501,27 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public int readIntLE() {
+        return 0;
+    }
+
+    @Override
     public long readUnsignedInt() {
         return 0;
     }
 
     @Override
+    public long readUnsignedIntLE() {
+        return 0;
+    }
+
+    @Override
     public long readLong() {
+        return 0;
+    }
+
+    @Override
+    public long readLongLE() {
         return 0;
     }
 
@@ -426,6 +547,11 @@ public class ZeroBuffer extends ByteBuf {
 
     @Override
     public ByteBuf readSlice(int i) {
+        return null;
+    }
+
+    @Override
+    public ByteBuf readRetainedSlice(int i) {
         return null;
     }
 
@@ -470,6 +596,16 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public CharSequence readCharSequence(int i, Charset charset) {
+        return null;
+    }
+
+    @Override
+    public int readBytes(FileChannel fileChannel, long l, int i) throws IOException {
+        return 0;
+    }
+
+    @Override
     public ByteBuf skipBytes(int i) {
         return null;
     }
@@ -490,7 +626,17 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeShortLE(int i) {
+        return null;
+    }
+
+    @Override
     public ByteBuf writeMedium(int i) {
+        return null;
+    }
+
+    @Override
+    public ByteBuf writeMediumLE(int i) {
         return null;
     }
 
@@ -500,7 +646,17 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeIntLE(int i) {
+        return null;
+    }
+
+    @Override
     public ByteBuf writeLong(long l) {
+        return null;
+    }
+
+    @Override
+    public ByteBuf writeLongLE(long l) {
         return null;
     }
 
@@ -560,8 +716,18 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public int writeBytes(FileChannel fileChannel, long l, int i) throws IOException {
+        return 0;
+    }
+
+    @Override
     public ByteBuf writeZero(int i) {
         return null;
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence charSequence, Charset charset) {
+        return 0;
     }
 
     @Override
@@ -585,22 +751,22 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
-    public int forEachByte(ByteBufProcessor byteBufProcessor) {
+    public int forEachByte(ByteProcessor byteProcessor) {
         return 0;
     }
 
     @Override
-    public int forEachByte(int i, int i1, ByteBufProcessor byteBufProcessor) {
+    public int forEachByte(int i, int i1, ByteProcessor byteProcessor) {
         return 0;
     }
 
     @Override
-    public int forEachByteDesc(ByteBufProcessor byteBufProcessor) {
+    public int forEachByteDesc(ByteProcessor byteProcessor) {
         return 0;
     }
 
     @Override
-    public int forEachByteDesc(int i, int i1, ByteBufProcessor byteBufProcessor) {
+    public int forEachByteDesc(int i, int i1, ByteProcessor byteProcessor) {
         return 0;
     }
 
@@ -620,12 +786,27 @@ public class ZeroBuffer extends ByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        return null;
+    }
+
+    @Override
     public ByteBuf slice(int i, int i1) {
         return null;
     }
 
     @Override
+    public ByteBuf retainedSlice(int i, int i1) {
+        return null;
+    }
+
+    @Override
     public ByteBuf duplicate() {
+        return null;
+    }
+
+    @Override
+    public ByteBuf retainedDuplicate() {
         return null;
     }
 
@@ -716,6 +897,16 @@ public class ZeroBuffer extends ByteBuf {
 
     @Override
     public ByteBuf retain(int i) {
+        return null;
+    }
+
+    @Override
+    public ByteBuf touch() {
+        return null;
+    }
+
+    @Override
+    public ByteBuf touch(Object o) {
         return null;
     }
 

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedDataWatcher.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedDataWatcher.java
@@ -495,7 +495,7 @@ public class WrappedDataWatcher extends AbstractWrapper implements Iterable<Wrap
 					.build();
 			List<Method> methods = fuzzy.getMethodList(contract);
 			for (Method method : methods) {
-				if (method.getName().equals("set") || method.getName().equals("watch")) {
+				if (method.getName().equals("set") || method.getName().equals("watch") || method.getName().equals("b")) {
 					SETTER = Accessors.getMethodAccessor(method);
 				} else {
 					REGISTER = Accessors.getMethodAccessor(method);

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedRegistry.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedRegistry.java
@@ -5,10 +5,10 @@ import com.comphenix.protocol.reflect.accessors.Accessors;
 import com.comphenix.protocol.reflect.accessors.MethodAccessor;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyMethodContract;
 import com.comphenix.protocol.utility.MinecraftReflection;
-import com.comphenix.protocol.utility.MinecraftVersion;
 import com.google.common.collect.ImmutableMap;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -46,13 +46,14 @@ public class WrappedRegistry {
 
         REGISTRY = ImmutableMap.copyOf(regMap);
 
-        if (MinecraftVersion.CAVES_CLIFFS_2.atOrAbove()) {
-            GET = Accessors.getMethodAccessor(regClass, "a", MinecraftReflection.getMinecraftKeyClass());
-        } else {
-            GET = Accessors.getMethodAccessor(regClass, "get", MinecraftReflection.getMinecraftKeyClass());
-        }
-
         FuzzyReflection fuzzy = FuzzyReflection.fromClass(regClass, false);
+        GET = Accessors.getMethodAccessor(fuzzy.getMethod(FuzzyMethodContract
+                .newBuilder()
+            		.parameterCount(1)
+            		.returnDerivedOf(Object.class)
+            		.requireModifier(Modifier.ABSTRACT)
+            		.parameterExactType(MinecraftReflection.getMinecraftKeyClass())
+            		.build()));
         GET_KEY = Accessors.getMethodAccessor(fuzzy.getMethod(FuzzyMethodContract
                 .newBuilder()
                 .parameterCount(1)

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedRegistry.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedRegistry.java
@@ -46,7 +46,11 @@ public class WrappedRegistry {
 
         REGISTRY = ImmutableMap.copyOf(regMap);
 
-        GET = Accessors.getMethodAccessor(regClass, "get", MinecraftReflection.getMinecraftKeyClass());
+        if (MinecraftVersion.CAVES_CLIFFS_2.atOrAbove()) {
+            GET = Accessors.getMethodAccessor(regClass, "a", MinecraftReflection.getMinecraftKeyClass());
+        } else {
+            GET = Accessors.getMethodAccessor(regClass, "get", MinecraftReflection.getMinecraftKeyClass());
+        }
 
         FuzzyReflection fuzzy = FuzzyReflection.fromClass(regClass, false);
         GET_KEY = Accessors.getMethodAccessor(fuzzy.getMethod(FuzzyMethodContract

--- a/src/test/java/com/comphenix/integration/protocol/SimpleCraftBukkitITCase.java
+++ b/src/test/java/com/comphenix/integration/protocol/SimpleCraftBukkitITCase.java
@@ -33,7 +33,7 @@ import com.google.common.io.Files;
 // TODO Migrate this to Gradle if necessary
 // Damn final classes ...
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "javax.management.*" })
 @PrepareForTest(PluginDescriptionFile.class)
 public class SimpleCraftBukkitITCase {
 	// The fake plugin

--- a/src/test/java/com/comphenix/integration/protocol/SimpleCraftBukkitITCase.java
+++ b/src/test/java/com/comphenix/integration/protocol/SimpleCraftBukkitITCase.java
@@ -33,7 +33,7 @@ import com.google.common.io.Files;
 // TODO Migrate this to Gradle if necessary
 // Damn final classes ...
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "org.apache.logging.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
 @PrepareForTest(PluginDescriptionFile.class)
 public class SimpleCraftBukkitITCase {
 	// The fake plugin

--- a/src/test/java/com/comphenix/protocol/BukkitInitialization.java
+++ b/src/test/java/com/comphenix/protocol/BukkitInitialization.java
@@ -1,11 +1,11 @@
 package com.comphenix.protocol;
 
+import com.comphenix.protocol.utility.MinecraftVersion;
 import java.util.Collections;
 import java.util.List;
 
 import com.comphenix.protocol.reflect.FieldUtils;
 import com.comphenix.protocol.utility.Constants;
-import com.mojang.bridge.game.GameVersion;
 
 import net.minecraft.SharedConstants;
 import net.minecraft.core.IRegistry;
@@ -16,10 +16,10 @@ import org.apache.logging.log4j.LogManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.v1_17_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemFactory;
-import org.bukkit.craftbukkit.v1_17_R1.util.Versioning;
+import org.bukkit.craftbukkit.v1_18_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_18_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_18_R1.inventory.CraftItemFactory;
+import org.bukkit.craftbukkit.v1_18_R1.util.Versioning;
 import org.spigotmc.SpigotWorldConfig;
 
 import static org.mockito.Mockito.mock;
@@ -81,7 +81,7 @@ public class BukkitInitialization {
 			instance.setPackage();
 
 			SharedConstants.a();
-			DispenserRegistry.init();
+			DispenserRegistry.a();
 
 			try {
 				IRegistry.class.getName();
@@ -89,12 +89,15 @@ public class BukkitInitialization {
 				ex.printStackTrace();
 			}
 
+			String releaseTarget = SharedConstants.b().getReleaseTarget();
+			String serverVersion = CraftServer.class.getPackage().getImplementationVersion();
+
 			// Mock the server object
 			Server mockedServer = mock(Server.class);
 
 			when(mockedServer.getLogger()).thenReturn(java.util.logging.Logger.getLogger("Minecraft"));
 			when(mockedServer.getName()).thenReturn("Mock Server");
-			when(mockedServer.getVersion()).thenReturn(CraftServer.class.getPackage().getImplementationVersion());
+			when(mockedServer.getVersion()).thenReturn(serverVersion + " (MC: " + releaseTarget + ")");
 			when(mockedServer.getBukkitVersion()).thenReturn(Versioning.getBukkitVersion());
 
 			when(mockedServer.getItemFactory()).thenReturn(CraftItemFactory.instance());

--- a/src/test/java/com/comphenix/protocol/BukkitInitialization.java
+++ b/src/test/java/com/comphenix/protocol/BukkitInitialization.java
@@ -1,6 +1,5 @@
 package com.comphenix.protocol;
 
-import com.comphenix.protocol.utility.MinecraftVersion;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
+++ b/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
@@ -76,7 +76,7 @@ import static org.junit.Assert.*;
 
 // Ensure that the CraftItemFactory is mockable
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "org.apache.logging.*", "org.bukkit.craftbukkit.libs.jline.*", "javax.management.*", "javax.xml.parsers.*", "com.sun.org.apache.xerces.internal.jaxp.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*", "javax.management.*", "javax.xml.parsers.*", "com.sun.org.apache.xerces.internal.jaxp.*" })
 //@PrepareForTest(CraftItemFactory.class)
 public class PacketContainerTest {
 	// Helper converters
@@ -191,7 +191,7 @@ public class PacketContainerTest {
 	@Test
 	public void testGetIntegerArrays() {
 		// Contains a byte array we will test
-		PacketContainer packet = new PacketContainer(PacketType.Play.Server.MAP_CHUNK);
+		PacketContainer packet = new PacketContainer(PacketType.Play.Server.MOUNT);
 		StructureModifier<int[]> integers = packet.getIntegerArrays();
 		int[] testArray = new int[] { 1, 2, 3 };
 
@@ -411,7 +411,7 @@ public class PacketContainerTest {
 		// are inner classes (which is ultimately pointless because AttributeSnapshots don't access any
 		// members of the packet itself)
 		PacketPlayOutUpdateAttributes packet = (PacketPlayOutUpdateAttributes) attribute.getHandle();
-		AttributeBase base = IRegistry.al.get(MinecraftKey.a("generic.max_health"));
+		AttributeBase base = IRegistry.am.a(MinecraftKey.a("generic.max_health"));
 		AttributeSnapshot snapshot = new AttributeSnapshot(base, 20.0D, modifiers);
 		attribute.getSpecificModifier(List.class).write(0, Lists.newArrayList(snapshot));
 
@@ -461,7 +461,7 @@ public class PacketContainerTest {
 	@SuppressWarnings("deprecation")
 	public void testPotionEffect() {
 		PotionEffect effect = new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 20 * 60, 1);
-		MobEffect mobEffect = new MobEffect(MobEffectList.fromId(effect.getType().getId()), effect.getDuration(), effect.getAmplifier(), effect.isAmbient(),
+		MobEffect mobEffect = new MobEffect(MobEffectList.a(effect.getType().getId()), effect.getDuration(), effect.getAmplifier(), effect.isAmbient(),
 				effect.hasParticles());
 		int entityId = 42;
 		
@@ -668,7 +668,7 @@ public class PacketContainerTest {
 		// this is a special case as we are generating a data serializer class (we only need to construct the packet)
 		PacketContainer container = new PacketContainer(PacketType.Play.Server.MAP_CHUNK);
 		// check if we can read an nbt compound from the class
-		assertTrue(container.getNbtModifier().optionRead(0).isPresent());
+		assertTrue(container.getStructures().read(0).getNbtModifier().optionRead(0).isPresent());
 	}
 
 	/**

--- a/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
+++ b/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
@@ -664,6 +664,14 @@ public class PacketContainerTest {
 	}
 
 	@Test
+	public void testSetSimulationDistance() {
+		// first packet which is a record - set will fail if we missed something during patching
+		PacketContainer container = new PacketContainer(PacketType.Play.Server.UPDATE_SIMULATION_DISTANCE);
+		container.getIntegers().write(0, 1234);
+		assertEquals(1234, (int) container.getIntegers().read(0));
+	}
+
+	@Test
 	public void testMapChunk() {
 		// this is a special case as we are generating a data serializer class (we only need to construct the packet)
 		PacketContainer container = new PacketContainer(PacketType.Play.Server.MAP_CHUNK);

--- a/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
+++ b/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
@@ -76,7 +76,7 @@ import static org.junit.Assert.*;
 
 // Ensure that the CraftItemFactory is mockable
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*", "javax.management.*", "javax.xml.parsers.*", "com.sun.org.apache.xerces.internal.jaxp.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "javax.management.*" })
 //@PrepareForTest(CraftItemFactory.class)
 public class PacketContainerTest {
 	// Helper converters

--- a/src/test/java/com/comphenix/protocol/injector/EntityUtilitiesTest.java
+++ b/src/test/java/com/comphenix/protocol/injector/EntityUtilitiesTest.java
@@ -9,6 +9,8 @@ import com.comphenix.protocol.reflect.accessors.Accessors;
 
 import com.comphenix.protocol.reflect.accessors.FieldAccessor;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyFieldContract;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.server.level.ChunkProviderServer;
 import net.minecraft.server.level.EntityTrackerEntry;
 import net.minecraft.server.level.PlayerChunkMap;
@@ -16,10 +18,8 @@ import net.minecraft.server.level.PlayerChunkMap.EntityTracker;
 import net.minecraft.server.level.WorldServer;
 import net.minecraft.world.entity.Entity;
 
-import org.bukkit.craftbukkit.libs.it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import org.bukkit.craftbukkit.libs.it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import org.bukkit.craftbukkit.v1_17_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_18_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftEntity;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public class EntityUtilitiesTest {
 		when(bukkit.getHandle()).thenReturn(world);
 
 		ChunkProviderServer provider = mock(ChunkProviderServer.class);
-		when(world.getChunkProvider()).thenReturn(provider);
+		when(world.k()).thenReturn(provider);
 
 		PlayerChunkMap chunkMap = mock(PlayerChunkMap.class);
 		Field chunkMapField = FuzzyReflection.fromClass(ChunkProviderServer.class, true)

--- a/src/test/java/com/comphenix/protocol/injector/PluginVerifierTest.java
+++ b/src/test/java/com/comphenix/protocol/injector/PluginVerifierTest.java
@@ -26,7 +26,7 @@ import com.google.common.collect.Lists;
 
 // Damn final classes
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "javax.management.*" })
 @PrepareForTest(PluginDescriptionFile.class)
 public class PluginVerifierTest {
 	@Test

--- a/src/test/java/com/comphenix/protocol/injector/PluginVerifierTest.java
+++ b/src/test/java/com/comphenix/protocol/injector/PluginVerifierTest.java
@@ -26,7 +26,7 @@ import com.google.common.collect.Lists;
 
 // Damn final classes
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "org.apache.logging.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
 @PrepareForTest(PluginDescriptionFile.class)
 public class PluginVerifierTest {
 	@Test

--- a/src/test/java/com/comphenix/protocol/injector/PluginVerifierTest.java
+++ b/src/test/java/com/comphenix/protocol/injector/PluginVerifierTest.java
@@ -1,7 +1,7 @@
 package com.comphenix.protocol.injector;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/comphenix/protocol/utility/MinecraftReflectionTest.java
+++ b/src/test/java/com/comphenix/protocol/utility/MinecraftReflectionTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v1_18_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Entity;
 import org.bukkit.inventory.ItemStack;
 import org.junit.AfterClass;
@@ -31,7 +31,7 @@ import net.minecraft.world.level.ChunkCoordIntPair;
 import net.minecraft.world.level.block.state.IBlockData;
 
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "org.apache.logging.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
 public class MinecraftReflectionTest {
 
 	@BeforeClass

--- a/src/test/java/com/comphenix/protocol/utility/MinecraftReflectionTest.java
+++ b/src/test/java/com/comphenix/protocol/utility/MinecraftReflectionTest.java
@@ -31,7 +31,7 @@ import net.minecraft.world.level.ChunkCoordIntPair;
 import net.minecraft.world.level.block.state.IBlockData;
 
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "javax.management.*" })
 public class MinecraftReflectionTest {
 
 	@BeforeClass

--- a/src/test/java/com/comphenix/protocol/utility/StreamSerializerTest.java
+++ b/src/test/java/com/comphenix/protocol/utility/StreamSerializerTest.java
@@ -19,7 +19,7 @@ import static com.comphenix.protocol.utility.TestUtils.assertItemsEqual;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "org.apache.logging.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
 //@PrepareForTest(CraftItemFactory.class)
 public class StreamSerializerTest {
 

--- a/src/test/java/com/comphenix/protocol/wrappers/ChunkCoordIntPairTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/ChunkCoordIntPairTest.java
@@ -26,7 +26,7 @@ public class ChunkCoordIntPairTest {
 			(net.minecraft.world.level.ChunkCoordIntPair) ChunkCoordIntPair.getConverter().
 			getGeneric(specific);
 
-		assertEquals(1, roundtrip.b);
-		assertEquals(2, roundtrip.c);
+		assertEquals(1, roundtrip.c);
+		assertEquals(2, roundtrip.d);
 	}
 }

--- a/src/test/java/com/comphenix/protocol/wrappers/MultiBlockChangeTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/MultiBlockChangeTest.java
@@ -33,7 +33,7 @@ import com.comphenix.protocol.utility.MinecraftReflection;
  * @author dmulloy2
  */
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "org.apache.logging.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
 public class MultiBlockChangeTest {
 
 	// @BeforeClass

--- a/src/test/java/com/comphenix/protocol/wrappers/MultiBlockChangeTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/MultiBlockChangeTest.java
@@ -33,7 +33,7 @@ import com.comphenix.protocol.utility.MinecraftReflection;
  * @author dmulloy2
  */
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "javax.management.*" })
 public class MultiBlockChangeTest {
 
 	// @BeforeClass

--- a/src/test/java/com/comphenix/protocol/wrappers/WrappedAttributeTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/WrappedAttributeTest.java
@@ -92,7 +92,7 @@ public class WrappedAttributeTest {
 			modifiers.add((AttributeModifier) wrapper.getHandle());
 		}
 
-		AttributeBase base = IRegistry.al.get(MinecraftKey.a(attribute.getAttributeKey()));
+		AttributeBase base = IRegistry.am.a(MinecraftKey.a(attribute.getAttributeKey()));
 		return new AttributeSnapshot(base, attribute.getBaseValue(), modifiers);
 	}
 

--- a/src/test/java/com/comphenix/protocol/wrappers/WrappedBlockDataTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/WrappedBlockDataTest.java
@@ -23,9 +23,9 @@ import net.minecraft.world.level.block.state.IBlockData;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.type.GlassPane;
-import org.bukkit.craftbukkit.v1_17_R1.block.data.CraftBlockData;
-import org.bukkit.craftbukkit.v1_17_R1.block.impl.CraftStainedGlassPane;
-import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
+import org.bukkit.craftbukkit.v1_18_R1.block.data.CraftBlockData;
+import org.bukkit.craftbukkit.v1_18_R1.block.impl.CraftStainedGlassPane;
+import org.bukkit.craftbukkit.v1_18_R1.util.CraftMagicNumbers;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -60,7 +60,7 @@ public class WrappedBlockDataTest {
 
 	@Test
 	public void testDataCreation() {
-		IBlockData nmsData = CraftMagicNumbers.getBlock(Material.CYAN_STAINED_GLASS_PANE).getBlockData();
+		IBlockData nmsData = CraftMagicNumbers.getBlock(Material.CYAN_STAINED_GLASS_PANE).n();
 		GlassPane data = (GlassPane) CraftBlockData.fromData(nmsData);
 		data.setFace(BlockFace.EAST, true);
 

--- a/src/test/java/com/comphenix/protocol/wrappers/WrappedDataWatcherTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/WrappedDataWatcherTest.java
@@ -25,8 +25,8 @@ import com.comphenix.protocol.wrappers.WrappedDataWatcher.WrappedDataWatcherObje
 
 import net.minecraft.world.entity.projectile.EntityEgg;
 
-import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEgg;
-import org.bukkit.craftbukkit.v1_17_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftEgg;
+import org.bukkit.craftbukkit.v1_18_R1.entity.CraftEntity;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/src/test/java/com/comphenix/protocol/wrappers/nbt/NbtFactoryTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/nbt/NbtFactoryTest.java
@@ -48,7 +48,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "javax.management.*" })
 //@PrepareForTest(CraftItemFactory.class)
 public class NbtFactoryTest {
 	@BeforeClass

--- a/src/test/java/com/comphenix/protocol/wrappers/nbt/NbtFactoryTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/nbt/NbtFactoryTest.java
@@ -48,7 +48,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
 @RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
-@PowerMockIgnore({ "org.apache.log4j.*", "org.apache.logging.*", "org.bukkit.craftbukkit.libs.jline.*" })
+@PowerMockIgnore({ "org.apache.logging.log4j.core.config.xml.*", "org.bukkit.craftbukkit.libs.jline.*" })
 //@PrepareForTest(CraftItemFactory.class)
 public class NbtFactoryTest {
 	@BeforeClass


### PR DESCRIPTION
This tracks the update changes to minecraft 1.18.

* 11-22-2021: Introduces support for the last spigot release 1.18-pre5 as announced [here](https://www.spigotmc.org/threads/9-years-of-spigotmc-spigot-bungeecord-1-18-pre5.534760/)
* 11-24-2021: Support for 1.18-pre8 - some packet classes are now records
* 11-30-2021: Caves and Cliffs Part II was released :tada: