### PR TITLE
Fix PacketDecoder super class compatibility

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
@@ -255,16 +255,19 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 				vanillaDecoder = (ByteToMessageDecoder) originalChannel.pipeline().get("decoder");
 			} catch (ClassCastException ignored) {
 				useCustomDecoder = true;
-			}
-			try {
-				customDecoder = (MessageToMessageDecoder<ByteBuf>) originalChannel.pipeline().get("decoder");
-			} catch (ClassCastException ignored) {
-				useCustomDecoder = false;
+				try {
+					customDecoder = (MessageToMessageDecoder<ByteBuf>) originalChannel.pipeline().get("decoder");
+				} catch (ClassCastException ignored1) {
+					useCustomDecoder = false;
+					throw new IllegalArgumentException("Unable to find vanilla or custom decoder in " + originalChannel.pipeline() + " (not supported implementation?)");
+				}
 			}
 			vanillaEncoder = (MessageToByteEncoder<Object>) originalChannel.pipeline().get("encoder");
 
-			if (vanillaDecoder == null && customDecoder == null) {
-				throw new IllegalArgumentException("Unable to find vanilla or custom decoder in " + originalChannel.pipeline());
+			if (!useCustomDecoder && vanillaDecoder == null) {
+				throw new IllegalArgumentException("Unable to find vanilla decoder in " + originalChannel.pipeline());
+			} else if (useCustomDecoder && customDecoder == null) {
+				throw new IllegalArgumentException("Unable to find custom decoder in " + originalChannel.pipeline());
 			}
 			if (vanillaEncoder == null) {
 				throw new IllegalArgumentException("Unable to find vanilla encoder in " + originalChannel.pipeline());

--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
@@ -247,7 +247,7 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 			}
 
 			// Get the vanilla decoder, so we don't have to replicate the work
-			vanillaDecoder = (ByteToMessageDecoder) originalChannel.pipeline().get("decoder");
+			vanillaDecoder = (ChannelInboundHandler) originalChannel.pipeline().get("decoder");
 
 			vanillaEncoder = (MessageToByteEncoder<Object>) originalChannel.pipeline().get("encoder");
 


### PR DESCRIPTION
Exception:
`[16:03:15 INFO]: UUID of player ImLew_x is 8806319a-0eee-40fd-9841-6b16515cfa21
[16:03:19 INFO]: Error Cannot execute code in channel thread. (java.lang.ClassCastException: class net.minecraft.server.v1_8_R3.PacketDecoder cannot be cast to class io.netty.handler.codec.ByteToMessageDecoder (net.minecraft.server.v1_8_R3.PacketDecoder and io.netty.handler.codec.ByteToMessageDecoder are in unnamed module of loader 'app')) occured in com.comphenix.protocol.injector.netty.ChannelInjector@6fc200b.
[16:03:19 ERROR]:   [ProtocolLib] INTERNAL ERROR: Cannot execute code in channel thread.
  If this problem hasn't already been reported, please open a ticket
  at https://github.com/dmulloy2/ProtocolLib/issues with the following data:
  Stack Trace:
  java.lang.ClassCastException: class net.minecraft.server.v1_8_R3.PacketDecoder cannot be cast to class io.netty.handler.codec.ByteToMessageDecoder (net.minecraft.server.v1_8_R3.PacketDecoder and io.netty.handler.codec.ByteToMessageDecoder are in unnamed module of loader 'app')
        at com.comphenix.protocol.injector.netty.ChannelInjector.inject(ChannelInjector.java:249)
        at com.comphenix.protocol.injector.netty.ChannelInjector.lambda$executeInChannelThread$3(ChannelInjector.java:917)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:500)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:829)`

This happens when the superclass of PacketDecoder isn't ByteToMessageDecoder, i added support to MessageToMessageDecoder without breaking the ByteToMessageDecoder support (or i think that, needs testing, i can't do because maven doesn't want to download 1.17, can someone give me compiled jar?)

DONT MERGE BEFORE TESTED