### PR TITLE
Prevent memory leaks with loads of PacketMarker objects

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
@@ -275,7 +275,7 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 				@Override
 				public void write(ChannelHandlerContext ctx, Object packet, ChannelPromise promise) throws Exception {
 					super.write(ctx, packet, promise);
-					ChannelInjector.this.finalWrite();
+					ChannelInjector.this.finalWrite(packet);
 				}
 
 				@Override
@@ -544,7 +544,7 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 	/**
 	 * Invoked when a packet has been written to the channel
 	 */
-	private void finalWrite() {
+	private void finalWrite(Object packet) {
 		PacketEvent event = finalEvent;
 
 		if (event != null) {
@@ -553,6 +553,10 @@ public class ChannelInjector extends ByteToMessageDecoder implements Injector {
 			currentEvent = null;
 
 			processor.invokePostEvent(event, NetworkMarker.getNetworkMarker(event));
+
+			// remove the stored packet markers to prevent memory leaks
+			// See: https://github.com/dmulloy2/ProtocolLib/issues/1509
+			packetMarker.remove(packet);
 		}
 	}
 


### PR DESCRIPTION
This pull request fixes a memory leak reported in #1509. Currently all packet markers are left in a WeakHashMap until they get garbage collected. If a packet processor now holds the reference of the packet object the garbage collector is unable to remove the marker and the marker will be left in memory.

To prevent this, I remove the packet marker after the packet was written and all processing steps were done. I confirmed that the memory leak was gone by taking a look with a profiler, as shown below. The map is still a weak map in case some markers get not removed by the method for whatever reason, to remove them automatically.

Heap usage before the change (the VM ran out of memory after consuming 8 GB of heap):
![image](https://user-images.githubusercontent.com/40468651/153252765-2867e36e-dcb4-4315-8356-deb00a2dec0b.png)

Heap usage after the change:
![image](https://user-images.githubusercontent.com/40468651/153252842-445e6d68-4154-4920-b14e-f483ba1a6981.png)

(This change compiles correctly and all tests are passing, see #1510 why it's not compiling with GH actions 😄 )
closes #1509