### PR TITLE
Remove unsafe reflection trying to access the modifiers field

### DIFF
--- a/src/main/java/com/comphenix/protocol/reflect/FieldUtils.java
+++ b/src/main/java/com/comphenix/protocol/reflect/FieldUtils.java
@@ -395,20 +395,12 @@ public class FieldUtils {
 		writeStaticField(field, value);
 	}
 
+	/**
+	 * @deprecated Use {@link #writeStaticField(Class, String, Object, boolean)} instead.
+	 */
+	@Deprecated
 	public static void writeStaticFinalField(Class<?> clazz, String fieldName, Object value, boolean forceAccess) throws Exception {
-		Field field = getField(clazz, fieldName, forceAccess);
-		if (field == null) {
-			throw new IllegalArgumentException("Cannot locate field " + fieldName + " in " + clazz);
-		}
-
-		field.setAccessible(true);
-
-		Field modifiersField = Field.class.getDeclaredField("modifiers");
-		modifiersField.setAccessible(true);
-		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
-		field.setAccessible(true);
-		field.set(null, value);
+		writeStaticField(clazz, fieldName, value, forceAccess);
 	}
 
 	/**

--- a/src/main/java/com/comphenix/protocol/reflect/StructureModifier.java
+++ b/src/main/java/com/comphenix/protocol/reflect/StructureModifier.java
@@ -308,7 +308,9 @@ public class StructureModifier<TField> {
 	 * @param fieldIndex - index of the field.
 	 * @param value - TRUE if this field should be read only, FALSE otherwise.
 	 * @throws FieldAccessException If we cannot modify the read-only status.
+	 * @deprecated In recent java versions (starting at 9) the modifier field is secured and will not be writeable.
 	 */
+	@Deprecated
 	public void setReadOnly(int fieldIndex, boolean value) throws FieldAccessException {
 		if (fieldIndex < 0 || fieldIndex >= data.size())
 			throw new IllegalArgumentException("Index parameter is not within [0 - " + data.size() + ")");
@@ -325,7 +327,9 @@ public class StructureModifier<TField> {
 	 * @param field - the field to change.
 	 * @param isReadOnly - TRUE if the field should be read only, FALSE otherwise.
 	 * @throws IllegalAccessException If an error occured.
+	 * @deprecated In recent java versions (starting at 9) the modifier field is secured and will not be writeable.
 	 */
+	@Deprecated
 	protected static void setFinalState(Field field, boolean isReadOnly) throws IllegalAccessException {
 	    if (isReadOnly)
 	    	FieldUtils.writeField((Object) field, "modifiers", field.getModifiers() | Modifier.FINAL, true);

--- a/src/main/java/com/comphenix/protocol/reflect/compiler/CompiledStructureModifier.java
+++ b/src/main/java/com/comphenix/protocol/reflect/compiler/CompiledStructureModifier.java
@@ -58,8 +58,6 @@ public abstract class CompiledStructureModifier extends StructureModifier<Object
 				throw new IllegalStateException("Cannot make compiled field " + fieldIndex + " read only.");
 			}
 		}
-		
-		super.setReadOnly(fieldIndex, value);
 	}
 	
 	// Speed up the default writer


### PR DESCRIPTION
This is no longer possible in recent java versions as the modifier field is registered to the reflection filter and writes will always fail. For backwards compatibility the methods are still there but there are no more internal usages of them.

In `FieldUtils` we can just use the `writeStaticField` method as it will be able to write to final fields without removing the modifier.

(This change compiles correctly and all tests are passing, see #1510 why it's not compiling with GH actions 😄 )