### PR TITLE
Update to 1.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<project.fullVersion>${project.version}</project.fullVersion>
 
 		<powermock.version>2.0.9</powermock.version>
-		<spigot.version>1.18.1-R0.1-SNAPSHOT</spigot.version>
+		<spigot.version>1.18.2-R0.1-SNAPSHOT</spigot.version>
 	</properties>
 
 	<build>

--- a/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
@@ -38,12 +38,12 @@ public class ProtocolLibrary {
 	/**
 	 * The maximum version ProtocolLib has been tested with.
 	 */
-	public static final String MAXIMUM_MINECRAFT_VERSION = "1.18";
+	public static final String MAXIMUM_MINECRAFT_VERSION = "1.18.2";
 
 	/**
-	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.18) was released.
+	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.18.2) was released.
 	 */
-	public static final String MINECRAFT_LAST_RELEASE_DATE = "2021-11-30";
+	public static final String MINECRAFT_LAST_RELEASE_DATE = "2022-02-28";
 
 	/**
 	 * Plugins that are currently incompatible with ProtocolLib.

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftProtocolVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftProtocolVersion.java
@@ -79,6 +79,8 @@ public class MinecraftProtocolVersion {
 
 		map.put(new MinecraftVersion(1, 18, 0), 757);
 		map.put(new MinecraftVersion(1, 18, 1), 757);
+		map.put(new MinecraftVersion(1, 18, 2), 758);
+
 		return map;
 	}
 


### PR DESCRIPTION
Updates ProtocolLib to 1.18.2, which gets relased (according to their announcement) on the 28. this month.