### PR TITLE
fix duplicate element creation when wrapping the bootstrap list

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/manager/ListeningList.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/manager/ListeningList.java
@@ -18,6 +18,9 @@ final class ListeningList implements List<Object> {
 	public ListeningList(List<Object> original, ChannelHandler channelHandler) {
 		this.original = original;
 		this.channelHandler = channelHandler;
+
+		// no need to copy all elements of the original list, but we need to inject them
+		original.forEach(this::processInsert);
 	}
 
 	@Override

--- a/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerInjector.java
@@ -204,11 +204,8 @@ public class NetworkManagerInjector implements ChannelListener {
 				// we need to synchronize accesses to the list ourselves, see Collections.SynchronizedCollection
 				//noinspection SynchronizationOnLocalVariableOrMethodParameter
 				synchronized (value) {
-					// then copy all old values into the new list
+					// override the list field with our list
 					List<Object> newList = Collections.synchronizedList(new ListeningList(value, this.pipelineInjectorHandler));
-					newList.addAll(value);
-
-					// rewrite the actual field
 					accessor.set(serverConnection, newList);
 				}
 			}


### PR DESCRIPTION
The old code takes all elements from the original, wrapped list and calls addAll on the newly created one. This causes the backing list of the operation to contain all elements twice. This is fixed now.

closes #1530