### PR TITLE
fix missing temp player in pre-join channel injectors

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/InjectionFactory.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/InjectionFactory.java
@@ -112,7 +112,14 @@ public class InjectionFactory {
 			}
 		} else {
 			// construct a new injector as it seems like we have none yet
-			injector = new NettyChannelInjector(this.server, networkManager, channel, listener, this, this.errorReporter);
+			injector = new NettyChannelInjector(
+					player,
+					this.server,
+					networkManager,
+					channel,
+					listener,
+					this,
+					this.errorReporter);
 			this.cacheInjector(player, injector);
 		}
 
@@ -162,6 +169,7 @@ public class InjectionFactory {
 		Player temporaryPlayer = playerFactory.createTemporaryPlayer(this.server);
 
 		NettyChannelInjector injector = new NettyChannelInjector(
+				temporaryPlayer,
 				this.server,
 				netManager,
 				channel,

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -110,6 +110,7 @@ public class NettyChannelInjector implements Injector {
 	private FieldAccessor protocolAccessor;
 
 	public NettyChannelInjector(
+			Player player,
 			Server server,
 			Object netManager,
 			Channel channel,
@@ -119,6 +120,7 @@ public class NettyChannelInjector implements Injector {
 	) {
 		// bukkit stuff
 		this.server = server;
+		this.resolvedPlayer = player;
 
 		// protocol lib stuff
 		this.errorReporter = errorReporter;


### PR DESCRIPTION
Fixes an issue with the player missing the injector when he didn't join the server yet. The temporary player wasn't given to the channel injector causing (for example) ServerListPlus to throw exceptions when a status request was sent to the server.
The original reporter confirmed this as the fix for the issue :)

closes #1534