### PR TITLE
Remove setCancelled / isCancelled from PacketInjector

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
@@ -222,11 +222,6 @@ public class PacketFilterManager implements ListenerInvoker, InternalManager {
 			}
 
 			Object nmsPacket = packet.getHandle();
-
-			// make sure packets which are force received through this method are never cancelled
-			boolean oldCancelState = this.packetInjector.isCancelled(nmsPacket);
-			this.packetInjector.setCancelled(nmsPacket, false);
-
 			// check to which listeners we need to post the packet
 			if (filters) {
 				// post to all listeners
@@ -244,7 +239,6 @@ public class PacketFilterManager implements ListenerInvoker, InternalManager {
 
 			// post to the player inject, reset our cancel state change
 			this.playerInjectionHandler.receiveClientPacket(sender, nmsPacket);
-			this.packetInjector.setCancelled(nmsPacket, oldCancelState);
 		}
 	}
 

--- a/src/main/java/com/comphenix/protocol/injector/packet/AbstractPacketInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/AbstractPacketInjector.java
@@ -3,7 +3,6 @@ package com.comphenix.protocol.injector.packet;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.concurrency.PacketTypeSet;
 import com.comphenix.protocol.events.ListenerOptions;
-import com.comphenix.protocol.injector.packet.PacketInjector;
 import java.util.Set;
 
 public abstract class AbstractPacketInjector implements PacketInjector {
@@ -12,17 +11,6 @@ public abstract class AbstractPacketInjector implements PacketInjector {
 
 	public AbstractPacketInjector(PacketTypeSet inboundFilters) {
 		this.inboundFilters = inboundFilters;
-	}
-
-	@Override
-	public boolean isCancelled(Object packet) {
-		// No, it's never cancelled
-		return false;
-	}
-
-	@Override
-	public void setCancelled(Object packet, boolean cancelled) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/main/java/com/comphenix/protocol/injector/packet/PacketInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/PacketInjector.java
@@ -15,22 +15,6 @@ import org.bukkit.entity.Player;
 public interface PacketInjector {
 
 	/**
-	 * Determine if a packet is cancelled or not.
-	 *
-	 * @param packet - the packet to check.
-	 * @return TRUE if it is, FALSE otherwise.
-	 */
-	boolean isCancelled(Object packet);
-
-	/**
-	 * Set whether or not a packet is cancelled.
-	 *
-	 * @param packet    - the packet to set.
-	 * @param cancelled - TRUE to cancel the packet, FALSE otherwise.
-	 */
-	void setCancelled(Object packet, boolean cancelled);
-
-	/**
 	 * Start intercepting packets with the given packet type.
 	 *
 	 * @param type    - the type of the packets to start intercepting.


### PR DESCRIPTION
This functionality is unused since the update to minecraft 1.7.2 (and is currently causing issues in v5). Cancellation is now only up to the packet events which are called during the packet receive rather than the packet injector.

closes #1552