### PR TITLE
fix packet listener invocation when packet is sent async

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
@@ -165,7 +165,7 @@ public class PacketFilterManager implements ListenerInvoker, InternalManager {
 					NetworkMarker copy = marker; // okay fine
 					this.server.getScheduler().scheduleSyncDelayedTask(
 							this.plugin,
-							() -> this.sendServerPacket(receiver, packet, copy, true));
+							() -> this.sendServerPacket(receiver, packet, copy, false));
 					return;
 				}
 

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -499,7 +499,7 @@ public class NettyChannelInjector implements Injector {
 			// not on the main thread but we are required to be - re-schedule the packet on the main thread
 			this.server.getScheduler().scheduleSyncDelayedTask(
 					this.injectionFactory.getPlugin(),
-					() -> this.sendServerPacket(packet, null, false));
+					() -> this.sendServerPacket(packet, null, true));
 			return null;
 		}
 


### PR DESCRIPTION
Async send packets (for example from the Async Chat Pool) would bypass the packet filters when sync listeners were registered for them on accident. Meanwhile re-scheduled packets from the async listeners would not bypass the listeners which caused an infinite loop as the packet was posted in a loop to the listeners.

Fixes #1576