### PR TITLE
Allow easier access to converters

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -7,6 +7,7 @@ import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.utility.MinecraftVersion;
 import com.comphenix.protocol.utility.StreamSerializer;
 import com.comphenix.protocol.wrappers.*;
+import com.comphenix.protocol.wrappers.WrappedProfilePublicKey.WrappedProfileKeyData;
 import com.comphenix.protocol.wrappers.nbt.NbtBase;
 import com.comphenix.protocol.wrappers.nbt.NbtCompound;
 import com.comphenix.protocol.wrappers.nbt.NbtFactory;
@@ -934,6 +935,26 @@ public abstract class AbstractStructure {
     }
 
     /**
+     * Retrieve a read/write structure for profile public keys in 1.9
+     * @return The Structure Modifier
+     */
+    public StructureModifier<WrappedProfilePublicKey> getProfilePublicKeys() {
+        return structureModifier.withType(
+            MinecraftReflection.getProfilePublicKeyClass(),
+            BukkitConverters.getWrappedProfilePublicKeyConverter());
+    }
+
+    /**
+     * Retrieve a read/write structure for profile public key data in 1.9
+     * @return The Structure Modifier
+     */
+    public StructureModifier<WrappedProfileKeyData> getProfilePublicKeyData() {
+        return structureModifier.withType(
+            MinecraftReflection.getProfilePublicKeyDataClass(),
+            BukkitConverters.getWrappedPublicKeyDataConverter());
+    }
+
+    /**
      * Retrieve a read/write structure for the Map class.
      * @param keyConverter Converter for map keys
      * @param valConverter Converter for map values
@@ -1007,6 +1028,19 @@ public abstract class AbstractStructure {
         return getEnumModifier(
                 enumClass,
                 structureModifier.getField(index).getType());
+    }
+
+    /**
+     * Retrieve a read/write structure for an optional, passing
+     * the value of the optional field through the given converter
+     * if present.
+     *
+     * @param converter Converter for internal element of optional, if present
+     * @param <T> The inner type of the optional
+     * @return The modifier
+     */
+    public <T> StructureModifier<Optional<T>> getOptionals(EquivalentConverter<T> converter) {
+        return structureModifier.withType(Optional.class, Converters.optional(converter));
     }
 
     /**

--- a/src/main/java/com/comphenix/protocol/events/InternalStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/InternalStructure.java
@@ -30,6 +30,10 @@ public class InternalStructure extends AbstractStructure {
         }
     };
 
+    public static EquivalentConverter<InternalStructure> getConverter() {
+        return CONVERTER;
+    }
+
     public StructureModifier<InternalStructure> getStructures() {
         return structureModifier.withType(Object.class, CONVERTER);
     }

--- a/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
@@ -538,7 +538,7 @@ public abstract class EnumWrappers {
 		associate(PARTICLE_CLASS, Particle.class, getParticleConverter());
 		associate(SOUND_CATEGORY_CLASS, SoundCategory.class, getSoundCategoryConverter());
 		associate(ITEM_SLOT_CLASS, ItemSlot.class, getItemSlotConverter());
-		associate(DIRECTION_CLASS,  Direction.class, getDirectionConverter());
+		associate(DIRECTION_CLASS, Direction.class, getDirectionConverter());
 		associate(CHAT_TYPE_CLASS, ChatType.class, getChatTypeConverter());
 		associate(HAND_CLASS, Hand.class, getHandConverter());
 		associate(ENTITY_USE_ACTION_CLASS, EntityUseAction.class, getEntityUseActionConverter());

--- a/src/test/java/com/comphenix/protocol/wrappers/WrappedProfilePublicKeyTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/WrappedProfilePublicKeyTest.java
@@ -1,0 +1,83 @@
+package com.comphenix.protocol.wrappers;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.comphenix.protocol.BukkitInitialization;
+import com.comphenix.protocol.wrappers.WrappedProfilePublicKey.WrappedProfileKeyData;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.time.Instant;
+import net.minecraft.world.entity.player.ProfilePublicKey;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class WrappedProfilePublicKeyTest {
+
+	private static KeyPair generateKeyPair() throws Exception {
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(2048);
+		return generator.generateKeyPair();
+	}
+
+	@BeforeAll
+	static void initializeBukkit() {
+		BukkitInitialization.initializeAll();
+	}
+
+	@Test
+	void testPublicKey() throws Exception {
+		KeyPair keyPair = generateKeyPair();
+		Instant timeout = Instant.now().plusSeconds(120);
+
+		// test key data conversion
+		WrappedProfileKeyData keyData = new WrappedProfileKeyData(timeout, keyPair.getPublic(), new byte[]{0x01, 0x0F});
+
+		Object handle = keyData.getHandle();
+		ProfilePublicKey.a data = assertInstanceOf(ProfilePublicKey.a.class, handle);
+
+		assertFalse(data.a());
+		assertEquals(timeout, data.b());
+		assertEquals(keyPair.getPublic(), data.c());
+		assertArrayEquals(keyData.getSignature(), data.d());
+
+		// test key data unwrapping
+		WrappedProfileKeyData unwrapped = BukkitConverters.getWrappedPublicKeyDataConverter().getSpecific(data);
+		assertNotNull(unwrapped);
+		assertFalse(unwrapped.isExpired());
+		assertEquals(keyData.getKey(), unwrapped.getKey());
+		assertEquals(keyData.getExpireTime(), unwrapped.getExpireTime());
+		assertArrayEquals(keyData.getSignature(), unwrapped.getSignature());
+
+		// test key data wrapping
+		Object wrappedData = BukkitConverters.getWrappedPublicKeyDataConverter().getGeneric(keyData);
+		ProfilePublicKey.a wrapped = assertInstanceOf(ProfilePublicKey.a.class, wrappedData);
+
+		assertFalse(wrapped.a());
+		assertEquals(timeout, wrapped.b());
+		assertEquals(keyPair.getPublic(), wrapped.c());
+		assertArrayEquals(keyData.getSignature(), wrapped.d());
+
+		// test profile key unwrapping
+		WrappedProfilePublicKey profilePublicKey = new WrappedProfilePublicKey(keyData);
+
+		Object keyHandle = profilePublicKey.getHandle();
+		ProfilePublicKey profileKey = assertInstanceOf(ProfilePublicKey.class, keyHandle);
+
+		assertNotNull(profileKey.b());
+
+		// test profile key wrapping
+		WrappedProfilePublicKey wrappedKey = BukkitConverters.getWrappedProfilePublicKeyConverter().getSpecific(keyHandle);
+		assertNotNull(wrappedKey);
+		assertNotNull(wrappedKey.getKeyData());
+
+		WrappedProfileKeyData wrappedKeyData = wrappedKey.getKeyData();
+		assertFalse(wrappedKeyData.isExpired());
+		assertEquals(keyData.getKey(), wrappedKeyData.getKey());
+		assertEquals(keyData.getExpireTime(), wrappedKeyData.getExpireTime());
+		assertArrayEquals(keyData.getSignature(), wrappedKeyData.getSignature());
+	}
+}


### PR DESCRIPTION
Allows easier access to the newly added ProfilePublicKey / ProfilePublicKeyData modifiers, as well as easy access to create an optional converter.

The InternalStructure converter is now publically accessible as well as there are some packets which contain List/Sets with structures which are not accessible without that converter being exposed (to use it in combination with f. ex. `getLists`).

Closes #1469