### PR TITLE
Allow easier access to registries

### DIFF
--- a/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
+++ b/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
@@ -21,7 +21,7 @@ import static com.comphenix.protocol.utility.TestUtils.equivalentItem;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -50,6 +50,7 @@ import com.comphenix.protocol.wrappers.WrappedDataWatcher.Registry;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher.WrappedDataWatcherObject;
 import com.comphenix.protocol.wrappers.WrappedEnumEntityUseAction;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
+import com.comphenix.protocol.wrappers.WrappedRegistry;
 import com.comphenix.protocol.wrappers.WrappedWatchableObject;
 import com.comphenix.protocol.wrappers.nbt.NbtCompound;
 import com.comphenix.protocol.wrappers.nbt.NbtFactory;
@@ -492,9 +493,12 @@ public class PacketContainerTest {
 		PacketContainer packet = creator.createPacket(entityId, mobEffect);
 
 		assertEquals(entityId, packet.getIntegers().read(0));
-		// assertEquals(effect.getType().getId(), packet.getIntegers().read(1));
 		assertEquals(effect.getAmplifier(), (byte) packet.getBytes().read(0));
 		assertEquals(effect.getDuration(), packet.getIntegers().read(1));
+
+		WrappedRegistry registry = WrappedRegistry.getRegistry(MinecraftReflection.getMobEffectListClass());
+		Object effectList = assertInstanceOf(MobEffectList.class, packet.getStructures().read(0).getHandle());
+		assertEquals(effect.getType().getId(), registry.getId(effectList));
 
 		int e = 0;
 		if (effect.isAmbient()) {

--- a/src/test/java/com/comphenix/protocol/wrappers/WrappedRegistryTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/WrappedRegistryTest.java
@@ -1,0 +1,51 @@
+package com.comphenix.protocol.wrappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.comphenix.protocol.BukkitInitialization;
+import com.comphenix.protocol.utility.MinecraftReflection;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.potion.PotionEffectType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class WrappedRegistryTest {
+
+	@BeforeAll
+	static void initialize() {
+		BukkitInitialization.initializeAll();
+	}
+
+	@Test
+	void testRegistries() {
+		// some randomly selected registries which we can proof to work using the bukkit api
+		validate(MinecraftReflection.getItemClass(), Material.DIAMOND_AXE.getKey());
+		validate(MinecraftReflection.getAttributeBase(), Attribute.GENERIC_MAX_HEALTH.getKey());
+		validate(MinecraftReflection.getSoundEffectClass(), Sound.ENTITY_WARDEN_SNIFF.getKey());
+		validate(MinecraftReflection.getMobEffectListClass(), PotionEffectType.REGENERATION.getKey());
+	}
+
+	void validate(Class<?> registryType, NamespacedKey key) {
+		WrappedRegistry registry = WrappedRegistry.getRegistry(registryType);
+		assertNotNull(registry);
+
+		Object registryEntry = registry.get(key.getKey());
+		assertNotNull(registryEntry);
+		assertInstanceOf(registryType, registryEntry);
+
+		MinecraftKey entryKey = registry.getKey(registryEntry);
+		assertEquals(key.getNamespace(), entryKey.getPrefix());
+		assertEquals(key.getKey(), entryKey.getKey());
+
+		int soundId = registry.getId(registryEntry);
+		assertNotEquals(-1, soundId);
+		assertEquals(soundId, registry.getId(entryKey));
+	}
+}
+


### PR DESCRIPTION
This allows to easily access all registries which are present in the IRegistry class (and fixes a bug where sub-type of IRegistry weren't registered due a wrong field type check).

Should be pretty easy to use, like:
```java
WrappedRegistry registry = WrappedRegistry.getRegistry(MinecraftReflection.getItemClass());
int itemId = registry.getId(Material.DIAMOND_AXE.getKey().getKey());
```