### PR TITLE
Add missing enum constants (1.19) & improve test

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
@@ -385,8 +385,14 @@ public abstract class EnumWrappers {
 		SPIN_ATTACK, 
 		CROUCHING,
 		LONG_JUMPING,
-		DYING;
-		
+		DYING,
+		CROAKING,
+		USING_TONGUE,
+		ROARING,
+		SNIFFING,
+		EMERGING,
+		DIGGING;
+
 		private final static EquivalentConverter<EntityPose> POSE_CONVERTER = EnumWrappers.getEntityPoseConverter();
 		
 		/**
@@ -522,7 +528,7 @@ public abstract class EnumWrappers {
 		CHAT_TYPE_CLASS = getEnum(PacketType.Play.Server.CHAT.getPacketClass(), 0);
 		ENTITY_POSE_CLASS = MinecraftReflection.getNullableNMS("world.entity.EntityPose", "EntityPose");
 
-		associate(PROTOCOL_CLASS, Protocol.class, getClientCommandConverter());
+		associate(PROTOCOL_CLASS, Protocol.class, getProtocolConverter());
 		associate(CLIENT_COMMAND_CLASS, ClientCommand.class, getClientCommandConverter());
 		associate(CHAT_VISIBILITY_CLASS, ChatVisibility.class, getChatVisibilityConverter());
 		associate(DIFFICULTY_CLASS, Difficulty.class, getDifficultyConverter());

--- a/src/test/java/com/comphenix/protocol/wrappers/EnumWrappersTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/EnumWrappersTest.java
@@ -1,20 +1,15 @@
 package com.comphenix.protocol.wrappers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.comphenix.protocol.BukkitInitialization;
 import com.comphenix.protocol.reflect.EquivalentConverter;
-import com.comphenix.protocol.reflect.accessors.Accessors;
-import com.comphenix.protocol.reflect.accessors.FieldAccessor;
 import com.google.common.collect.Sets;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
-import net.minecraft.core.EnumDirection;
-import net.minecraft.network.EnumProtocol;
-import net.minecraft.network.protocol.game.PacketPlayInClientCommand.EnumClientCommand;
-import net.minecraft.world.EnumDifficulty;
-import net.minecraft.world.EnumHand;
-import net.minecraft.world.entity.player.EnumChatVisibility;
-import net.minecraft.world.level.EnumGamemode;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -27,53 +22,36 @@ public class EnumWrappersTest {
 	@BeforeAll
 	public static void initializeBukkit() {
 		BukkitInitialization.initializeAll();
+		EnumWrappers.getPlayerInfoActionClass(); // just to initialize the classes and converters
 	}
 
 	@Test
-	public void testEnum() {
-		EnumClass obj = new EnumClass();
-		obj.protocol = EnumProtocol.a;
-		obj.command = EnumClientCommand.b;
-		obj.visibility = EnumChatVisibility.c;
-		obj.difficulty = EnumDifficulty.d;
-		obj.hand = EnumHand.b;
-		// obj.action = EnumEntityUseAction.INTERACT;
-		obj.mode = EnumGamemode.e;
-		obj.direction = EnumDirection.f;
-
-		assertEquals(obj.protocol, this.roundtrip(obj, "protocol", EnumWrappers.getProtocolConverter()));
-		assertEquals(obj.command, this.roundtrip(obj, "command", EnumWrappers.getClientCommandConverter()));
-		assertEquals(obj.visibility, this.roundtrip(obj, "visibility", EnumWrappers.getChatVisibilityConverter()));
-		assertEquals(obj.difficulty, this.roundtrip(obj, "difficulty", EnumWrappers.getDifficultyConverter()));
-		assertEquals(obj.hand, this.roundtrip(obj, "hand", EnumWrappers.getHandConverter()));
-		// assertEquals(obj.action, roundtrip(obj, "action", EnumWrappers.getEntityUseActionConverter()) );
-		assertEquals(obj.mode, this.roundtrip(obj, "mode", EnumWrappers.getGameModeConverter()));
-		assertEquals(obj.direction, this.roundtrip(obj, "direction", EnumWrappers.getDirectionConverter()));
-	}
-
 	@SuppressWarnings("unchecked")
-	public <T extends Enum<T>> T roundtrip(Object target, String fieldName, EquivalentConverter<T> converter) {
-		FieldAccessor accessor = Accessors.getFieldAccessor(target.getClass(), fieldName, true);
+	public void validateAllEnumFieldsAreWrapped() {
+		Map<Class<?>, EquivalentConverter<?>> nativeEnums = EnumWrappers.getFromNativeMap();
+		for (Entry<Class<?>, EquivalentConverter<?>> entry : nativeEnums.entrySet()) {
+			for (Object nativeConstant : entry.getKey().getEnumConstants()) {
+				try {
+					// yay, generics
+					EquivalentConverter<Object> converter = (EquivalentConverter<Object>) entry.getValue();
 
-		return (T) converter.getGeneric(
-				converter.getSpecific(accessor.get(target))
-		);
+					// try to convert the native constant to a wrapper and back
+					Object wrappedValue = converter.getSpecific(nativeConstant);
+					assertNotNull(wrappedValue);
+
+					Object unwrappedValue = converter.getGeneric(wrappedValue);
+					assertNotNull(unwrappedValue);
+
+					assertEquals(nativeConstant, unwrappedValue);
+				} catch (Exception exception) {
+					fail(exception);
+				}
+			}
+		}
 	}
 
 	@Test
 	public void testValidity() {
 		assertEquals(EnumWrappers.INVALID, KNOWN_INVALID);
-	}
-
-	private static class EnumClass {
-
-		public EnumProtocol protocol;
-		public EnumClientCommand command;
-		public EnumChatVisibility visibility;
-		public EnumDifficulty difficulty;
-		public EnumHand hand;
-		// public EnumEntityUseAction action; // moved to PacketPlayInUseEntity but is private
-		public EnumGamemode mode;
-		public EnumDirection direction;
 	}
 }


### PR DESCRIPTION
Adds the new entity pose enum constants add improves the enum wrapper test which now completely verifies that there is a wrapper enum constant for each native enum constant.

Fixed a small bug as well, where the protocol enum was using the player action converter causing a conversion failure.