### PR TITLE
fix compile issues introduced by latest spigot api changes

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/SerializedOfflinePlayer.java
+++ b/src/main/java/com/comphenix/protocol/events/SerializedOfflinePlayer.java
@@ -164,6 +164,11 @@ class SerializedOfflinePlayer implements OfflinePlayer, Serializable {
 	public void setStatistic(Statistic statistic, EntityType entityType, int i) { }
 
 	@Override
+	public Location getLastDeathLocation() {
+		return null;
+	}
+
+	@Override
 	public long getFirstPlayed() {
 		return firstPlayed;
 	}


### PR DESCRIPTION
Spigot introduced a new method `getLastDeathLocation` which we need to implement in order to be able to compile again.