### PR TITLE
allow setting if chat preview is enabled in WrappedServerPing

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -51,6 +51,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 	private static FieldAccessor PLAYERS = Accessors.getFieldAccessor(SERVER_PING, MinecraftReflection.getServerPingPlayerSampleClass(), true);
 	private static FieldAccessor VERSION = Accessors.getFieldAccessor(SERVER_PING, MinecraftReflection.getServerPingServerDataClass(), true);
 	private static FieldAccessor FAVICON = Accessors.getFieldAccessor(SERVER_PING, String.class, true);
+	private static FieldAccessor PREVIEWS_CHAT = Accessors.getFieldAccessor(SERVER_PING, boolean.class, true);
 
 	// For converting to the underlying array
 	private static EquivalentConverter<Iterable<? extends WrappedGameProfile>> PROFILE_CONVERT =
@@ -179,6 +180,24 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 	 */
 	public void setFavicon(CompressedImage image) {
 		FAVICON.set(handle, (image != null) ? image.toEncodedText() : null);
+	}
+
+	/**
+	 * Retrieve whether chat preview is enabled on the server.
+	 * @return whether chat preview is enabled on the server.
+	 * @since 1.19
+	 */
+	public boolean isChatPreviewEnabled() {
+		return (Boolean) PREVIEWS_CHAT.get(handle);
+	}
+
+	/**
+	 * Sets whether chat preview is enabled on the server.
+	 * @param chatPreviewEnabled true if enabled, false otherwise.
+	 * @since 1.19
+	 */
+	public void setChatPreviewEnabled(boolean chatPreviewEnabled) {
+		PREVIEWS_CHAT.set(handle, chatPreviewEnabled);
 	}
 
 	/**

--- a/src/test/java/com/comphenix/protocol/wrappers/WrappedServerPingTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/WrappedServerPingTest.java
@@ -2,6 +2,7 @@ package com.comphenix.protocol.wrappers;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.comphenix.protocol.BukkitInitialization;
@@ -31,11 +32,13 @@ public class WrappedServerPingTest {
 			serverPing.setVersionName("Minecraft 123");
 			serverPing.setVersionProtocol(4);
 			serverPing.setFavicon(tux);
+			serverPing.setChatPreviewEnabled(true);
 
 			assertEquals(5, serverPing.getPlayersOnline());
 			assertEquals(10, serverPing.getPlayersMaximum());
 			assertEquals("Minecraft 123", serverPing.getVersionName());
 			assertEquals(4, serverPing.getVersionProtocol());
+			assertTrue(serverPing.isChatPreviewEnabled());
 
 			assertArrayEquals(original, serverPing.getFavicon().getData());
 


### PR DESCRIPTION
For some reason the server sends if chat preview is enabled during pinging the server (and then enables it via a separate packet on join) which can now be done via the WrappedServerPing as well.

Thanks to @LOOHP for pointing that out!