### PR TITLE
Fix registration of parameterized registry types

### DIFF
--- a/src/test/java/com/comphenix/protocol/wrappers/WrappedRegistryTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/WrappedRegistryTest.java
@@ -11,6 +11,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.EntityType;
 import org.bukkit.potion.PotionEffectType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ public class WrappedRegistryTest {
 	@Test
 	void testRegistries() {
 		// some randomly selected registries which we can proof to work using the bukkit api
+		validate(MinecraftReflection.getEntityTypes(), EntityType.WARDEN.getKey());
 		validate(MinecraftReflection.getItemClass(), Material.DIAMOND_AXE.getKey());
 		validate(MinecraftReflection.getAttributeBase(), Attribute.GENERIC_MAX_HEALTH.getKey());
 		validate(MinecraftReflection.getSoundEffectClass(), Sound.ENTITY_WARDEN_SNIFF.getKey());


### PR DESCRIPTION
Basically during testing I found that some registries aren't registried to the wrapped registry map as their types are parameterized as well, like `EntityType<T extends Entity>` which makes them unusable. This is fixed now.

The weird looking wildcard check basically prevents the registration of (currently only) Codec or any type which is nested deeper. There are some Registries which would have duplicate base keys:
```
Registry<Codec<? extends BiomeSource>> BIOME_SOURCE
Registry<Codec<? extends ChunkGenerator>> CHUNK_GENERATOR
Registry<Codec<? extends SurfaceRules.ConditionSource>> CONDITION
Registry<Codec<? extends SurfaceRules.RuleSource>> RULE
Registry<Codec<? extends DensityFunction>> DENSITY_FUNCTION_TYPES
```
But it currently makes no sense to change the WrappedRegistry functionality to support these as they have no direct protocol relation at all.