### PR TITLE
Fix error warning when using deprecated packets on older server versions

### DIFF
--- a/src/main/java/com/comphenix/protocol/PacketType.java
+++ b/src/main/java/com/comphenix/protocol/PacketType.java
@@ -317,25 +317,25 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 			 * @deprecated Removed in 1.19
 			 */
 			@Deprecated
-			public static final PacketType SPAWN_ENTITY_LIVING = new PacketType(PROTOCOL, SENDER, 246, "SpawnEntityLiving", "SPacketSpawnMob");
+			public static final PacketType SPAWN_ENTITY_LIVING = new PacketType(PROTOCOL, SENDER, 244, "SpawnEntityLiving", "SPacketSpawnMob");
 
 			/**
 			 * @deprecated Removed in 1.19
 			 */
 			@Deprecated
-			public static final PacketType SPAWN_ENTITY_PAINTING = new PacketType(PROTOCOL, SENDER, 247, "SpawnEntityPainting", "SPacketSpawnPainting");
+			public static final PacketType SPAWN_ENTITY_PAINTING = new PacketType(PROTOCOL, SENDER, 243, "SpawnEntityPainting", "SPacketSpawnPainting");
 
 			/**
 			 * @deprecated Removed in 1.19
 			 */
 			@Deprecated
-			public static final PacketType ADD_VIBRATION_SIGNAL = new PacketType(PROTOCOL, SENDER, 248, "AddVibrationSignal");
+			public static final PacketType ADD_VIBRATION_SIGNAL = new PacketType(PROTOCOL, SENDER, 242, "AddVibrationSignal");
 
 			/**
 			 * @deprecated Removed in 1.19
 			 */
 			@Deprecated
-			public static final PacketType BLOCK_BREAK = new PacketType(PROTOCOL, SENDER, 249, "BlockBreak");
+			public static final PacketType BLOCK_BREAK = new PacketType(PROTOCOL, SENDER, 241, "BlockBreak");
 
 			private final static Server INSTANCE = new Server();
 

--- a/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
@@ -55,7 +55,7 @@ public class PacketFilterManager implements ListenerInvoker, InternalManager {
 
 	// listener registration reports
 	private static final ReportType UNSUPPORTED_PACKET = new ReportType(
-			"Plugin %s tried to register listener for unknown packet %s [direction: to %s]");
+			"Plugin %s tried to register listener for unknown packet %s [direction: from %s]");
 
 	// bukkit references
 	private final Plugin plugin;


### PR DESCRIPTION
I accidentally counted the invalid packet ids up instead of down, causing them to collide with other deprecated packets. This leads to an error message being shown that the packet type is unsupported while it is supported.

Also fixes a small style thing causing the display of `[direction: to SERVER]` for clientbound packets (now displays `[direction: from SERVER]`)

Closes #1624