### PR TITLE
correctly mark changed packet as processed

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -540,11 +540,11 @@ public class NettyChannelInjector implements Injector {
 			// if the marker is null we can just schedule the action as we don't need to do anything after the packet was sent
 			NetworkMarker eventMarker = NetworkMarker.getNetworkMarker(event);
 			if (eventMarker == null) {
-				return this.markProcessed(packet, action, markSeen);
+				return this.markProcessed(interceptedPacket, action, markSeen);
 			}
 
 			// we need to wrap the action to call the listeners set in the marker
-			return this.markProcessed(packet, this.proxyAction(action, event, eventMarker), markSeen);
+			return this.markProcessed(interceptedPacket, this.proxyAction(action, event, eventMarker), markSeen);
 		}
 
 		// return null if the event was cancelled to schedule a no-op event


### PR DESCRIPTION
This issue was introduced in https://github.com/dmulloy2/ProtocolLib/commit/4db1e39ac76743bf1775249c1749161dd5f4909e because I didn't think about people who change outbound packets in a packet listener. Basdically (reconstructed from a spark report I got) plugins are doing something like (for whatever reason):
```java
public void onPacketSending(PacketEvent event) {
  PacketContainer cloned = event.getPacket().shallowClone();
  // modification of cloned packet
  event.setPacket(cloned);
}
```

which causes the old packet to be marked as processed, and the new packet will trigger the packet event call again when written, causing the packet listener call etc.

Closes #1631 #1637 #1638