### PR TITLE
fix exceptions on older server versions

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/PlayerInfoData.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/PlayerInfoData.java
@@ -177,9 +177,12 @@ public class PlayerInfoData {
 							MinecraftReflection.getIChatBaseComponentClass(), BukkitConverters.getWrappedChatComponentConverter());
 					WrappedChatComponent displayName = displayNames.read(0);
 
-					StructureModifier<WrappedProfileKeyData> keyData = modifier.withType(
-							MinecraftReflection.getProfilePublicKeyDataClass(), BukkitConverters.getWrappedPublicKeyDataConverter());
-					WrappedProfileKeyData key = keyData.optionRead(0).orElse(null);
+					WrappedProfileKeyData key = null;
+					if (MinecraftVersion.WILD_UPDATE.atOrAbove()) {
+						StructureModifier<WrappedProfileKeyData> keyData = modifier.withType(
+								MinecraftReflection.getProfilePublicKeyDataClass(), BukkitConverters.getWrappedPublicKeyDataConverter());
+						key = keyData.read(0);
+					}
 
 					return new PlayerInfoData(gameProfile, latency, gameMode, displayName, key);
 				}

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -51,7 +51,7 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 	private static FieldAccessor PLAYERS = Accessors.getFieldAccessor(SERVER_PING, MinecraftReflection.getServerPingPlayerSampleClass(), true);
 	private static FieldAccessor VERSION = Accessors.getFieldAccessor(SERVER_PING, MinecraftReflection.getServerPingServerDataClass(), true);
 	private static FieldAccessor FAVICON = Accessors.getFieldAccessor(SERVER_PING, String.class, true);
-	private static FieldAccessor PREVIEWS_CHAT = Accessors.getFieldAccessor(SERVER_PING, boolean.class, true);
+	private static FieldAccessor PREVIEWS_CHAT;
 
 	// For converting to the underlying array
 	private static EquivalentConverter<Iterable<? extends WrappedGameProfile>> PROFILE_CONVERT =
@@ -188,6 +188,11 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 	 * @since 1.19
 	 */
 	public boolean isChatPreviewEnabled() {
+		if (PREVIEWS_CHAT == null) {
+			// TODO: at some point we should make everything nullable to make updates easier
+			// see https://github.com/dmulloy2/ProtocolLib/issues/1644 for an example reference
+			PREVIEWS_CHAT = Accessors.getFieldAccessor(SERVER_PING, boolean.class, true);
+		}
 		return (Boolean) PREVIEWS_CHAT.get(handle);
 	}
 
@@ -197,6 +202,9 @@ public class WrappedServerPing extends AbstractWrapper implements ClonableWrappe
 	 * @since 1.19
 	 */
 	public void setChatPreviewEnabled(boolean chatPreviewEnabled) {
+		if (PREVIEWS_CHAT == null) {
+			PREVIEWS_CHAT = Accessors.getFieldAccessor(SERVER_PING, boolean.class, true);
+		}
 		PREVIEWS_CHAT.set(handle, chatPreviewEnabled);
 	}
 


### PR DESCRIPTION
Currently exceptions are thrown left and right due to indirect initilization of some classes which are trying to resolve stuff which doesn't exist.

The solution here is maybe not the best, but as already noted in one todo, we should rather make the accessor system more reliable against these kinds of changes to make it easier and cleaner to update to newer server versions (possibly after 1.19 is stable and #1561 done).

Closes #1644