### PR TITLE
Improve getEntityFromID

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/EntityUtilities.java
+++ b/src/main/java/com/comphenix/protocol/injector/EntityUtilities.java
@@ -28,6 +28,7 @@ import com.comphenix.protocol.utility.MinecraftFields;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.utility.MinecraftVersion;
 import com.comphenix.protocol.wrappers.WrappedIntHashMap;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,6 +57,7 @@ class EntityUtilities {
 	private FieldAccessor trackedPlayersField;
 	private FieldAccessor trackedEntitiesField;
 
+	private MethodAccessor getEntity;
 	private MethodAccessor getChunkProvider;
 
 	private EntityUtilities() {
@@ -81,6 +83,20 @@ class EntityUtilities {
 		Object trackerEntry = this.getEntityTrackerEntry(entity.getWorld(), entity.getEntityId());
 		this.scanPlayersMethods.computeIfAbsent(trackerEntry.getClass(), this::findScanPlayers)
 				.invoke(trackerEntry, nmsPlayers);
+	}
+
+	public Entity getEntity(World world, int id) {
+		Object level = BukkitUnwrapper.getInstance().unwrapItem(world);
+		if (getEntity == null) {
+			Method entityGetter = FuzzyReflection.fromObject(level).getMethodByParameters(
+					"getEntity",
+					MinecraftReflection.getEntityClass(),
+					new Class[]{int.class});
+			getEntity = Accessors.getMethodAccessor(entityGetter);
+		}
+
+		Object entity = getEntity.invoke(level, id);
+		return (Entity) MinecraftReflection.getBukkitEntity(entity);
 	}
 
 	private MethodAccessor findScanPlayers(Class<?> trackerClass) {

--- a/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
@@ -401,12 +401,7 @@ public class PacketFilterManager implements ListenerInvoker, InternalManager {
 
 	@Override
 	public Entity getEntityFromID(World container, int id) {
-		for (Entity entity : container.getEntities()) {
-			if (entity.getEntityId() == id) {
-				return entity;
-			}
-		}
-		return null;
+		return EntityUtilities.getInstance().getEntity(container, id);
 	}
 
 	@Override


### PR DESCRIPTION
Improves the behaviour of `PacketFilterManager#getEntityFromID` by accessing the level entities directly from the world rather than looping over `World#getEntities` which is very inefficient (it allocates a new list and runs some checks against the entity which are not required for us). This even breaks the old behaviour as it only makes entities visible which are in loaded chunks.

Closes #1583, Closes #1631, Closes #1566