### PR TITLE
don't suppress deserialization issues

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/PacketContainer.java
+++ b/src/main/java/com/comphenix/protocol/events/PacketContainer.java
@@ -307,7 +307,7 @@ public class PacketContainer extends AbstractStructure implements Serializable {
 					handle = type.getPacketClass()
 							.getConstructor(MinecraftReflection.getPacketDataSerializerClass())
 							.newInstance(serializer);
-				} catch (ReflectiveOperationException ex) {
+				} catch (NoSuchMethodException | IllegalAccessException | InstantiationException ex) {
 					// they might have a static method to create them instead
 					Method method = FuzzyReflection.fromClass(type.getPacketClass(), true)
 							.getMethod(FuzzyMethodContract
@@ -318,9 +318,11 @@ public class PacketContainer extends AbstractStructure implements Serializable {
 									.build());
 					try {
 						handle = method.invoke(null, serializer);
-					} catch (ReflectiveOperationException ignored) {
-						throw new RuntimeException("Failed to construct packet for " + type, ex);
+					} catch (ReflectiveOperationException exception) {
+						throw new RuntimeException("Failed to construct packet for " + type, exception);
 					}
+				} catch (InvocationTargetException ex) {
+					throw new RuntimeException("Unable to clone packet " + type + " using constructor", ex.getCause());
 				}
 			} else {
 				handle = StructureCache.newPacket(type);


### PR DESCRIPTION
Currently the real cloning exceptions are supressed, as when creating a packet using a constructor there might be exceptions thrown during deserialization which aren't handled. There will be an attempt to look for a static read method instead (which in most cases doesn't exist) so the lookup will throw an exception instead.

See #1734 as an example of that, the original issue is the bungee component api which isn't able to correctly serialize a component, the read process throws an exception which is ignored and an "cannot find static method" error is thrown instead. 