### PR TITLE
add support for sync & async receiving listeners

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/InboundPacketInterceptor.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/InboundPacketInterceptor.java
@@ -1,8 +1,5 @@
 package com.comphenix.protocol.injector.netty.channel;
 
-import com.comphenix.protocol.events.NetworkMarker;
-import com.comphenix.protocol.events.PacketEvent;
-import com.comphenix.protocol.injector.NetworkProcessor;
 import com.comphenix.protocol.injector.netty.ChannelListener;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import io.netty.channel.ChannelHandlerContext;
@@ -12,47 +9,36 @@ final class InboundPacketInterceptor extends ChannelInboundHandlerAdapter {
 
 	private final NettyChannelInjector injector;
 	private final ChannelListener channelListener;
-	private final NetworkProcessor networkProcessor;
 
-	public InboundPacketInterceptor(NettyChannelInjector injector, ChannelListener listener, NetworkProcessor processor) {
+	public InboundPacketInterceptor(NettyChannelInjector injector, ChannelListener listener) {
 		this.injector = injector;
 		this.channelListener = listener;
-		this.networkProcessor = processor;
 	}
 
 	@Override
 	public void channelRead(ChannelHandlerContext ctx, Object msg) {
-		if (this.shouldInterceptMessage(msg)) {
+		Class<?> messageClass = msg.getClass();
+		if (this.shouldInterceptMessage(messageClass)) {
 			// process the login if the packet is one before posting the packet to any handler to provide "real" data
 			// the method invocation will do nothing if the packet is not a login packet
 			this.injector.tryProcessLogin(msg);
 
-			// call packet handlers, a null result indicates that we shouldn't change anything
-			PacketEvent interceptionResult = this.channelListener.onPacketReceiving(this.injector, msg, null);
-			if (interceptionResult == null) {
+			// check if there are any listeners bound for the packet - if not just post the packet down the pipeline
+			if (!this.channelListener.hasListener(messageClass)) {
 				ctx.fireChannelRead(msg);
 				return;
 			}
 
-			// fire the intercepted packet down the pipeline if it wasn't cancelled
-			if (!interceptionResult.isCancelled()) {
-				ctx.fireChannelRead(interceptionResult.getPacket().getHandle());
-
-				// check if there were any post events added the packet after we fired it down the pipeline
-				// we use this way as we don't want to construct a new network manager accidentally
-				NetworkMarker marker = NetworkMarker.getNetworkMarker(interceptionResult);
-				if (marker != null) {
-					this.networkProcessor.invokePostEvent(interceptionResult, marker);
-				}
-			}
+			// call all inbound listeners
+			this.injector.processInboundPacket(ctx, msg, messageClass);
 		} else {
 			// just pass the message down the pipeline
 			ctx.fireChannelRead(msg);
 		}
 	}
 
-	private boolean shouldInterceptMessage(Object msg) {
+	private boolean shouldInterceptMessage(Class<?> messageClass) {
 		// only intercept minecraft packets and no garbage from other stuff in the channel
-		return MinecraftReflection.getPacketClass().isAssignableFrom(msg.getClass());
+		return MinecraftReflection.getPacketClass().isAssignableFrom(messageClass);
 	}
 }

--- a/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerInjector.java
@@ -1,5 +1,12 @@
 package com.comphenix.protocol.injector.netty.manager;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLogger;
 import com.comphenix.protocol.concurrency.PacketTypeSet;
@@ -23,12 +30,6 @@ import com.comphenix.protocol.reflect.fuzzy.FuzzyMethodContract;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.wrappers.Pair;
 import io.netty.channel.ChannelFuture;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 
@@ -78,7 +79,11 @@ public class NetworkManagerInjector implements ChannelListener {
 				this,
 				this.injectionFactory,
 				this.mainThreadListeners);
-		this.packetInjector = new NetworkManagerPacketInjector(this.inboundListeners, this.listenerInvoker, this);
+		this.packetInjector = new NetworkManagerPacketInjector(
+				this.inboundListeners,
+				this.listenerInvoker,
+				this,
+				this.mainThreadListeners);
 	}
 
 	@Override

--- a/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerPacketInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerPacketInjector.java
@@ -1,23 +1,49 @@
 package com.comphenix.protocol.injector.netty.manager;
 
+import java.util.Set;
+
+import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.concurrency.PacketTypeSet;
+import com.comphenix.protocol.events.ListenerOptions;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.injector.ListenerInvoker;
-import com.comphenix.protocol.injector.packet.AbstractPacketInjector;
 import com.comphenix.protocol.injector.netty.ChannelListener;
+import com.comphenix.protocol.injector.packet.AbstractPacketInjector;
 import org.bukkit.entity.Player;
 
 final class NetworkManagerPacketInjector extends AbstractPacketInjector {
 
 	private final ListenerInvoker invoker;
 	private final ChannelListener channelListener;
+	private final PacketTypeSet mainThreadListeners;
 
-	public NetworkManagerPacketInjector(PacketTypeSet inboundFilters, ListenerInvoker invoker, ChannelListener listener) {
+	public NetworkManagerPacketInjector(
+			PacketTypeSet inboundFilters,
+			ListenerInvoker invoker,
+			ChannelListener listener,
+			PacketTypeSet mainThreadListeners
+	) {
 		super(inboundFilters);
 
 		this.invoker = invoker;
 		this.channelListener = listener;
+		this.mainThreadListeners = mainThreadListeners;
+	}
+
+	@Override
+	public boolean addPacketHandler(PacketType type, Set<ListenerOptions> options) {
+		if (!type.isAsyncForced() && (options == null || !options.contains(ListenerOptions.ASYNC))) {
+			this.mainThreadListeners.addType(type);
+		}
+
+		return super.addPacketHandler(type, options);
+	}
+
+	@Override
+	public boolean removePacketHandler(PacketType type) {
+		this.mainThreadListeners.removeType(type);
+		return super.removePacketHandler(type);
 	}
 
 	@Override
@@ -26,5 +52,10 @@ final class NetworkManagerPacketInjector extends AbstractPacketInjector {
 		this.invoker.invokePacketReceiving(event);
 
 		return event;
+	}
+
+	@Override
+	public boolean hasMainThreadListener(PacketType type) {
+		return this.mainThreadListeners.contains(type);
 	}
 }

--- a/src/main/java/com/comphenix/protocol/injector/packet/PacketInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/PacketInjector.java
@@ -1,10 +1,11 @@
 package com.comphenix.protocol.injector.packet;
 
+import java.util.Set;
+
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.ListenerOptions;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
-import java.util.Set;
 import org.bukkit.entity.Player;
 
 /**
@@ -54,6 +55,14 @@ public interface PacketInjector {
 	 * @return The resulting packet event.
 	 */
 	PacketEvent packetReceived(PacketContainer packet, Player client);
+
+	/**
+	 * Determine if we have packet listeners with the given type that must be executed on the main thread.
+	 *
+	 * @param type - the packet type.
+	 * @return TRUE if we do, FALSE otherwise.
+	 */
+	boolean hasMainThreadListener(PacketType type);
 
 	/**
 	 * Perform any necessary cleanup before unloading ProtocolLib.

--- a/src/main/java/com/comphenix/protocol/injector/player/PlayerInjectionHandler.java
+++ b/src/main/java/com/comphenix/protocol/injector/player/PlayerInjectionHandler.java
@@ -1,12 +1,13 @@
 package com.comphenix.protocol.injector.player;
 
+import java.util.Set;
+
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.ListenerOptions;
 import com.comphenix.protocol.events.NetworkMarker;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketListener;
 import io.netty.channel.Channel;
-import java.util.Set;
 import org.bukkit.entity.Player;
 
 public interface PlayerInjectionHandler {
@@ -121,8 +122,6 @@ public interface PlayerInjectionHandler {
 
 	/**
 	 * Determine if we have packet listeners with the given type that must be executed on the main thread.
-	 * <p>
-	 * This only applies for onPacketSending(), as it makes certain guarantees.
 	 *
 	 * @param type - the packet type.
 	 * @return TRUE if we do, FALSE otherwise.


### PR DESCRIPTION
Add support to register receive listeners to call them either async or on the main thread. There was a lot of confusion in issues when receive listeners for (seemingly) some reason were called async without spcifying the async option - directly on the netty event loop. This is an issue for 2 reasons:
 1. some plugins want to access bukkit api in receive listeners, like getting the interacted block.
 2. doing stuff on the netty event loop blocks that event loop from doing other stuff, like polling more inbound messages which can lead to delays (especially considering that spigot limits event loop threads to 4 by default). Therefore I moved incoming events to an async bukkit scheduler thread if the receive process is called in the event loop (which it always should be). A small reference what can happen when doing work on the event loop vs. not doing it can be seen here: https://twitter.com/fbrasisil/status/1163974576511995904
 3. if a plugin decided to go the "cancel packet -> sync work -> use `Injector#receiveClientPacket`" way it prevented other channel listeners from being able to do work with the plugin. Normally there shouldn't be any vanilla decoders after our decoder, but for example other plugins that hooked into the pipeline might have issue seeing intercepted packets.