### PR TITLE
Improve cloning tests

### DIFF
--- a/src/main/java/com/comphenix/protocol/reflect/StructureModifier.java
+++ b/src/main/java/com/comphenix/protocol/reflect/StructureModifier.java
@@ -327,14 +327,10 @@ public class StructureModifier<T> {
 			return this;
 		}
 
-		// just write the value if the specific given one is null or no conversion is needed
-		if (value == null || !this.needConversion()) {
-			accessor.set(this.target, value);
-			return this;
-		}
-
 		// convert and write
-		accessor.set(this.target, this.converter.getGeneric(value));
+		Object fieldValue = this.needConversion() ? this.converter.getGeneric(value) : value;
+		accessor.set(this.target, fieldValue);
+
 		return this;
 	}
 

--- a/src/main/java/com/comphenix/protocol/reflect/StructureModifier.java
+++ b/src/main/java/com/comphenix/protocol/reflect/StructureModifier.java
@@ -269,13 +269,8 @@ public class StructureModifier<T> {
 			return null;
 		}
 
-		// don't try to convert null, just return null
+		// get the field value and convert it if needed
 		Object fieldValue = accessor.get(this.target);
-		if (fieldValue == null) {
-			return null;
-		}
-
-		// check if we need to convert the field value and do so if needed
 		return this.needConversion() ? this.converter.getSpecific(fieldValue) : (T) fieldValue;
 	}
 

--- a/src/main/java/com/comphenix/protocol/reflect/cloning/ImmutableDetector.java
+++ b/src/main/java/com/comphenix/protocol/reflect/cloning/ImmutableDetector.java
@@ -76,6 +76,9 @@ public class ImmutableDetector implements Cloner {
 			add("world.entity.npc.VillagerProfession", "VillagerProfession");
 		}
 
+		add("world.entity.animal.CatVariant");
+		add("world.entity.animal.FrogVariant");
+
 		// TODO automatically detect the technically-not-an-enum enums that Mojang is so fond of
 		// Would also probably go in tandem with having the FieldCloner use this
 

--- a/src/main/java/com/comphenix/protocol/reflect/instances/PrimitiveGenerator.java
+++ b/src/main/java/com/comphenix/protocol/reflect/instances/PrimitiveGenerator.java
@@ -2,55 +2,64 @@
  *  ProtocolLib - Bukkit server library that allows access to the Minecraft protocol.
  *  Copyright (C) 2012 Kristian S. Stangeland
  *
- *  This program is free software; you can redistribute it and/or modify it under the terms of the 
- *  GNU General Public License as published by the Free Software Foundation; either version 2 of 
+ *  This program is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU General Public License as published by the Free Software Foundation; either version 2 of
  *  the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
- *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License along with this program; 
- *  if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 
+ *  You should have received a copy of the GNU General Public License along with this program;
+ *  if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
  *  02111-1307 USA
  */
 
 package com.comphenix.protocol.reflect.instances;
 
 import java.lang.reflect.Array;
-
-import javax.annotation.Nullable;
+import java.util.Optional;
 
 import com.google.common.base.Defaults;
 import com.google.common.primitives.Primitives;
+import javax.annotation.Nullable;
 
 /**
- * Provides constructors for primtive types, wrappers, arrays and strings.
+ * Provides constructors for primitive java types and wrappers.
+ *
  * @author Kristian
  */
 public class PrimitiveGenerator implements InstanceProvider {
-	
+
 	/**
 	 * Default value for Strings.
 	 */
+	@Deprecated
 	public static final String STRING_DEFAULT = "";
-	
+
 	/**
 	 * Shared instance of this generator.
 	 */
-	public static PrimitiveGenerator INSTANCE = new PrimitiveGenerator(STRING_DEFAULT);
+	public static PrimitiveGenerator INSTANCE = new PrimitiveGenerator();
 
 	// Our default string value
-	private String stringDefault;
-	
+	private final String stringDefault;
+
+	public PrimitiveGenerator() {
+		this.stringDefault = "";
+	}
+
+	@Deprecated
 	public PrimitiveGenerator(String stringDefault) {
 		this.stringDefault = stringDefault;
 	}
-	
+
 	/**
 	 * Retrieve the string default.
+	 *
 	 * @return Default instance of a string.
 	 */
+	@Deprecated
 	public String getStringDefault() {
 		return stringDefault;
 	}
@@ -68,13 +77,16 @@ public class PrimitiveGenerator implements InstanceProvider {
 			return Array.newInstance(arrayType, 0);
 		} else if (type.isEnum()) {
 			Object[] values = type.getEnumConstants();
-			if (values != null && values.length > 0)
+			if (values != null && values.length > 0) {
 				return values[0];
+			}
 		} else if (type.equals(String.class)) {
-			return stringDefault;
-		} 
-		
+			return this.stringDefault;
+		} else if (type.equals(Optional.class)) {
+			return Optional.empty();
+		}
+
 		// Cannot handle this type
 		return null;
-	}	
+	}
 }

--- a/src/main/java/com/comphenix/protocol/utility/ZeroBuffer.java
+++ b/src/main/java/com/comphenix/protocol/utility/ZeroBuffer.java
@@ -366,7 +366,7 @@ public class ZeroBuffer extends ByteBuf {
 
 	@Override
 	public short readUnsignedByte() {
-		return 0;
+		return 255;
 	}
 
 	@Override

--- a/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
+++ b/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
@@ -78,9 +78,6 @@ import net.minecraft.world.entity.ai.attributes.AttributeBase;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.animal.CatVariant;
 import net.minecraft.world.entity.animal.FrogVariant;
-import net.minecraft.world.entity.npc.VillagerData;
-import net.minecraft.world.entity.npc.VillagerProfession;
-import net.minecraft.world.entity.npc.VillagerType;
 import org.apache.commons.lang.SerializationUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -858,9 +855,6 @@ public class PacketContainerTest {
 							new WrappedWatchableObject(
 									new WrappedDataWatcherObject(0, Registry.getItemStackSerializer(false)),
 									BukkitConverters.getItemStackConverter().getGeneric(new ItemStack(Material.WOODEN_AXE))),
-							new WrappedWatchableObject(
-									new WrappedDataWatcherObject(0, Registry.get(VillagerData.class)),
-									new VillagerData(VillagerType.b, VillagerProfession.c, 69)),
 							new WrappedWatchableObject(
 									new WrappedDataWatcherObject(0, Registry.get(CatVariant.class)),
 									CatVariant.a),


### PR DESCRIPTION
Fixes some issues / improves some tiny parts as well:
 1. the packet constructing method via buffer is now preferred as it creates in all cases a packet which has default values applied to it. This should resolve some reported issues where packets had invalid null fields after creation.
 2. The InstanceGenerator for primitive types now covers optionals as well - they shouldn't be null.
 3. StructureModifier read/writes wouldn't call the converters for null field values which was wrong.
 4. ZeroBuffer#readUnsignedByte now always returns 255 instead of 0. This could have side effects on other packet creations, but fixes an infinite loop in DataWatcher deserialization as there is data read from the buffer until it return 255.
 5. The cloning tests now test all 3 cloning ways: Via shallow, deep & serialization. I also added more data to the watcher items for ENTITY_METADATA and added a check which validates that a cloned packet can be serialized by it's write method.