### PR TITLE
implement force async logic for inbound packets

### DIFF
--- a/src/main/java/com/comphenix/protocol/PacketType.java
+++ b/src/main/java/com/comphenix/protocol/PacketType.java
@@ -50,6 +50,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 		public static class Client extends PacketTypeEnum {
 			private final static Sender SENDER = Sender.CLIENT;
 
+			@ForceAsync
 			public static final PacketType SET_PROTOCOL =                 new PacketType(PROTOCOL, SENDER, 0x00, "SetProtocol", "C00Handshake");
 
 			private final static Client INSTANCE = new Client();
@@ -457,6 +458,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 
 			@ForceAsync
 			public static final PacketType SERVER_INFO =                  new PacketType(PROTOCOL, SENDER, 0x00, "ServerInfo", "SPacketServerInfo");
+			@ForceAsync
 			public static final PacketType PONG =                         new PacketType(PROTOCOL, SENDER, 0x01, "Pong", "SPacketPong");
 
 			/**
@@ -487,6 +489,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 			private final static Sender SENDER = Sender.CLIENT;
 
 			public static final PacketType START =                        new PacketType(PROTOCOL, SENDER, 0x00, "Start", "CPacketServerQuery");
+			@ForceAsync
 			public static final PacketType PING =                         new PacketType(PROTOCOL, SENDER, 0x01, "Ping", "CPacketPing");
 
 			private final static Client INSTANCE = new Client();

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -24,6 +24,7 @@ import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.injector.NetworkProcessor;
 import com.comphenix.protocol.injector.netty.ChannelListener;
 import com.comphenix.protocol.injector.netty.Injector;
+import com.comphenix.protocol.injector.packet.PacketRegistry;
 import com.comphenix.protocol.reflect.FuzzyReflection;
 import com.comphenix.protocol.reflect.accessors.Accessors;
 import com.comphenix.protocol.reflect.accessors.FieldAccessor;
@@ -501,7 +502,10 @@ public class NettyChannelInjector implements Injector {
 			return;
 		}
 
-		if (ctx.channel().eventLoop().inEventLoop()) {
+		// check the async force status - in the context of incoming listeners this is more a "check execution should
+		// be directly on calling thread" thing, but the method is already there and suits the use case the best
+		PacketType packetType = PacketRegistry.getPacketType(packetClass);
+		if (!packetType.isAsyncForced() && ctx.channel().eventLoop().inEventLoop()) {
 			// we're in a netty event loop - prevent that from happening as it slows down netty
 			// in normal cases netty only has 4 processing threads available which is *really* bad when we're
 			// then blocking these (or more specifically a plugin) to process the incoming packet


### PR DESCRIPTION
Some packets (in the pinging process) needs to get executed directly. These include:
 - Handshake: SET_PROTOCOL - the next packets (ping request, login begin) are sent immediately after the first packet, if they are handled before that packet than clients will be disconnected for no reason.
 - Ping: PING, PONG - these packets are just implemented stupidly on the client side. When the client receives a ping response, it will mark the server as available and schedule a server list update the next tick -> if we delay the ping request / pong response on the server side the server data will show up but the server will be marked as "No connection".

While the force async thing means something different as the name suggests (it should be named like force direct - that applies for outbound listeners as well: async will call the packet events on the caller thread, not in an async context), inbound packet listeners will now be called on the event loop directly instead of an async context.

Closes #1828