### PR TITLE
cleanup MonitorAdapter

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/MonitorAdapter.java
+++ b/src/main/java/com/comphenix/protocol/events/MonitorAdapter.java
@@ -2,82 +2,76 @@
  *  ProtocolLib - Bukkit server library that allows access to the Minecraft protocol.
  *  Copyright (C) 2012 Kristian S. Stangeland
  *
- *  This program is free software; you can redistribute it and/or modify it under the terms of the 
- *  GNU General Public License as published by the Free Software Foundation; either version 2 of 
+ *  This program is free software; you can redistribute it and/or modify it under the terms of the
+ *  GNU General Public License as published by the Free Software Foundation; either version 2 of
  *  the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
- *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License along with this program; 
- *  if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 
+ *  You should have received a copy of the GNU General Public License along with this program;
+ *  if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
  *  02111-1307 USA
  */
 
 package com.comphenix.protocol.events;
 
+import java.util.Collection;
 import java.util.logging.Logger;
 
+import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.injector.packet.PacketRegistry;
-
 import org.bukkit.plugin.Plugin;
 
 /**
  * Represents a listener that is notified of every sent and received packet.
- * 
+ *
  * @author Kristian
  */
 public abstract class MonitorAdapter implements PacketListener {
 
-	private Plugin plugin;
-	private ListeningWhitelist sending = ListeningWhitelist.EMPTY_WHITELIST;
-	private ListeningWhitelist receiving = ListeningWhitelist.EMPTY_WHITELIST;
+	private final Plugin plugin;
+	private final ListeningWhitelist sending;
+	private final ListeningWhitelist receiving;
 
 	public MonitorAdapter(Plugin plugin, ConnectionSide side) {
-		initialize(plugin, side, getLogger(plugin));
-	}
-	
-	public MonitorAdapter(Plugin plugin, ConnectionSide side, Logger logger) {
-		initialize(plugin, side, logger);
-	}
-
-	private void initialize(Plugin plugin, ConnectionSide side, Logger logger) {
 		this.plugin = plugin;
 
-		// Recover in case something goes wrong
-		if (side.isForServer())
-			this.sending = ListeningWhitelist.newBuilder().monitor().types(PacketRegistry.getServerPacketTypes()).gamePhaseBoth().build();
-		if (side.isForClient())
-			this.receiving = ListeningWhitelist.newBuilder().monitor().types(PacketRegistry.getClientPacketTypes()).gamePhaseBoth().build();
+		// check the connection side and register the packets for the given side
+		this.sending = side.isForServer() ? buildWhitelist(PacketRegistry.getServerPacketTypes()) : ListeningWhitelist.EMPTY_WHITELIST;
+		this.receiving = side.isForClient() ? buildWhitelist(PacketRegistry.getClientPacketTypes()) : ListeningWhitelist.EMPTY_WHITELIST;
 	}
 
-	/**
-	 * Retrieve a logger, even if we're running in a CraftBukkit version that doesn't support it.
-	 * @param plugin - the plugin to retrieve.
-	 * @return The logger.
-	 */
-	private Logger getLogger(Plugin plugin) {
-		try {
-			return plugin.getLogger();
-		} catch (NoSuchMethodError e) {
-			return Logger.getLogger("Minecraft");
-		}
+	@Deprecated
+	public MonitorAdapter(Plugin plugin, ConnectionSide side, Logger logger) {
+		this(plugin, side);
 	}
-	
+
+	private static ListeningWhitelist buildWhitelist(Collection<PacketType> packetTypes) {
+		return ListeningWhitelist.newBuilder().monitor().gamePhaseBoth().types(packetTypes).build();
+	}
+
 	@Override
 	public ListeningWhitelist getSendingWhitelist() {
-		return sending;
+		return this.sending;
 	}
-	
+
 	@Override
 	public ListeningWhitelist getReceivingWhitelist() {
-		return receiving;
+		return this.receiving;
 	}
-	
+
 	@Override
 	public Plugin getPlugin() {
-		return plugin;
+		return this.plugin;
+	}
+
+	@Override
+	public void onPacketSending(PacketEvent event) {
+	}
+
+	@Override
+	public void onPacketReceiving(PacketEvent event) {
 	}
 }
-


### PR DESCRIPTION
Small cleanup to the monitor adapter class. The only real change is that the constructor which takes an unused logger instance is now deprecated and redirect it's called into the constructor without the logger. All fields are now final too.

Overriding onPacketSending / onPacketReciving makes it easier to use the class (for example if you only want to get all outbound packets you no longer need to override onPacketReciving an vice-versa)