### PR TITLE
Make getRandomKey() properly random

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Random;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
@@ -44,6 +45,8 @@ import org.bukkit.Server;
 import org.bukkit.entity.Player;
 
 public class NettyChannelInjector implements Injector {
+
+	private static final Random RANDOM = new Random();
 
 	// an accessor used when we're unable to retrieve the actual packet field in an outbound packet send
 	private static final FieldAccessor NO_OP_ACCESSOR = new FieldAccessor() {
@@ -170,7 +173,7 @@ public class NettyChannelInjector implements Injector {
 	}
 
 	private static String getRandomKey() {
-		return Long.toString(System.nanoTime());
+		return "ProtocolLib-" + RANDOM.nextLong();
 	}
 
 	private static boolean hasProtocolLibHandler(Channel channel) {

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -9,9 +9,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Random;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -45,8 +45,6 @@ import org.bukkit.Server;
 import org.bukkit.entity.Player;
 
 public class NettyChannelInjector implements Injector {
-
-	private static final Random RANDOM = new Random();
 
 	// an accessor used when we're unable to retrieve the actual packet field in an outbound packet send
 	private static final FieldAccessor NO_OP_ACCESSOR = new FieldAccessor() {
@@ -173,7 +171,7 @@ public class NettyChannelInjector implements Injector {
 	}
 
 	private static String getRandomKey() {
-		return "ProtocolLib-" + RANDOM.nextLong();
+		return "ProtocolLib-" + ThreadLocalRandom.current().nextLong();
 	}
 
 	private static boolean hasProtocolLibHandler(Channel channel) {


### PR DESCRIPTION
In some scenarios, the system time source might give two identical values for `System.nanoTime()` during class intialization. This can cause a `ClassCastException` when we're trying to read the channel attributes, since the keys are no longer unique. This PR changes the `getRandomKey()` Method, so that we generate a proper pseudo-random number.