### PR TITLE
mark some critical packets as forced-async

### DIFF
--- a/src/main/java/com/comphenix/protocol/PacketType.java
+++ b/src/main/java/com/comphenix/protocol/PacketType.java
@@ -50,6 +50,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 		public static class Client extends PacketTypeEnum {
 			private final static Sender SENDER = Sender.CLIENT;
 
+			@ForceAsync
 			public static final PacketType SET_PROTOCOL =                 new PacketType(PROTOCOL, SENDER, 0x00, "SetProtocol", "C00Handshake");
 
 			private final static Client INSTANCE = new Client();
@@ -457,6 +458,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 
 			@ForceAsync
 			public static final PacketType SERVER_INFO =                  new PacketType(PROTOCOL, SENDER, 0x00, "ServerInfo", "SPacketServerInfo");
+			@ForceAsync
 			public static final PacketType PONG =                         new PacketType(PROTOCOL, SENDER, 0x01, "Pong", "SPacketPong");
 
 			/**
@@ -487,6 +489,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 			private final static Sender SENDER = Sender.CLIENT;
 
 			public static final PacketType START =                        new PacketType(PROTOCOL, SENDER, 0x00, "Start", "CPacketServerQuery");
+			@ForceAsync
 			public static final PacketType PING =                         new PacketType(PROTOCOL, SENDER, 0x01, "Ping", "CPacketPing");
 
 			private final static Client INSTANCE = new Client();


### PR DESCRIPTION
Some packets (in the pinging/login process) needs to get executed directly. These include:
 - Handshake: SET_PROTOCOL - the next packets (ping request, login begin) are sent immediately after the first packet, if they are handled before that packet than clients will be disconnected for no reason.
 - Ping: PING, PONG - these packets are just implemented stupidly on the client side. When the client receives a ping response, it will mark the server as available and schedule a server list update the next tick, then send out a ping request -> if we delay the ping request / pong response on the server side the server data will show up but the server will be marked as "No connection".
 
Closes #1844