### PR TITLE
Support Mojang mapped servers

### DIFF
--- a/src/main/java/com/comphenix/protocol/reflect/cloning/ImmutableDetector.java
+++ b/src/main/java/com/comphenix/protocol/reflect/cloning/ImmutableDetector.java
@@ -62,12 +62,12 @@ public class ImmutableDetector implements Cloner {
 		add(MinecraftReflection::getDataWatcherSerializerClass);
 		add(MinecraftReflection::getBlockClass);
 		add(MinecraftReflection::getItemClass);
-		add("sounds.SoundEffect", "SoundEffect");
+		add("sounds.SoundEffect", "sounds.SoundEvents", "SoundEffect");
 
 		if (MinecraftVersion.AQUATIC_UPDATE.atOrAbove()) {
 			add(MinecraftReflection::getFluidTypeClass);
 			add(MinecraftReflection::getParticleTypeClass);
-			add("core.particles.Particle", "Particle");
+			add("core.particles.Particle","core.particles.ParticleType", "Particle");
 		}
 
 		if (MinecraftVersion.VILLAGE_UPDATE.atOrAbove()) {
@@ -83,7 +83,7 @@ public class ImmutableDetector implements Cloner {
 		// Would also probably go in tandem with having the FieldCloner use this
 
 		if (MinecraftVersion.NETHER_UPDATE.atOrAbove()) {
-			add("core.IRegistry", "IRegistry");
+			add("core.IRegistry", "core.Registry", "IRegistry");
 		}
 
 		if (MinecraftVersion.NETHER_UPDATE_2.atOrAbove()) {

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -472,7 +472,7 @@ public final class MinecraftReflection {
 	 */
 	public static Class<?> getEntityPlayerClass() {
 		try {
-			return getMinecraftClass("server.level.EntityPlayer", "EntityPlayer");
+			return getMinecraftClass("server.level.EntityPlayer", "server.level.ServerPlayer", "EntityPlayer");
 		} catch (RuntimeException e) {
 			try {
 				// Grab CraftPlayer's handle
@@ -514,7 +514,7 @@ public final class MinecraftReflection {
 	 */
 	public static Class<?> getEntityClass() {
 		try {
-			return getMinecraftClass("server.world.Entity", "Entity");
+			return getMinecraftClass("server.level.Entity", "server.level.ServerEntity", "Entity");
 		} catch (RuntimeException e) {
 			return fallbackMethodReturn("Entity", "entity.CraftEntity", "getHandle");
 		}
@@ -536,7 +536,7 @@ public final class MinecraftReflection {
 	 */
 	public static Class<?> getWorldServerClass() {
 		try {
-			return getMinecraftClass("server.level.WorldServer", "WorldServer");
+			return getMinecraftClass("server.level.WorldServer", "server.level.ServerLevel", "WorldServer");
 		} catch (RuntimeException e) {
 			return fallbackMethodReturn("WorldServer", "CraftWorld", "getHandle");
 		}
@@ -549,7 +549,7 @@ public final class MinecraftReflection {
 	 */
 	public static Class<?> getNmsWorldClass() {
 		try {
-			return getMinecraftClass("world.level.World", "World");
+			return getMinecraftClass("world.level.World", "world.level.Level", "World");
 		} catch (RuntimeException e) {
 			return setMinecraftClass("World", getWorldServerClass().getSuperclass());
 		}
@@ -590,7 +590,7 @@ public final class MinecraftReflection {
 	 * @return The Enum protocol class.
 	 */
 	public static Class<?> getEnumProtocolClass() {
-		return getMinecraftClass("network.EnumProtocol", "EnumProtocol");
+		return getMinecraftClass("network.EnumProtocol", "network.ConnectionProtocol", "EnumProtocol");
 	}
 
 	/**
@@ -599,7 +599,7 @@ public final class MinecraftReflection {
 	 * @return The IChatBaseComponent.
 	 */
 	public static Class<?> getIChatBaseComponentClass() {
-		return getMinecraftClass("network.chat.IChatBaseComponent", "network.chat.IChatbaseComponent", "IChatBaseComponent");
+		return getMinecraftClass("network.chat.IChatBaseComponent", "network.chat.IChatbaseComponent", "network.chat.Component", "IChatBaseComponent");
 	}
 
 	public static Class<?> getIChatBaseComponentArrayClass() {
@@ -612,7 +612,7 @@ public final class MinecraftReflection {
 	 * @return The chat component class.
 	 */
 	public static Class<?> getChatComponentTextClass() {
-		return getMinecraftClass("network.chat.ChatComponentText", "ChatComponentText");
+		return getMinecraftClass("network.chat.ChatComponentText", "network.chat.TextComponent", "ChatComponentText");
 	}
 
 	/**
@@ -622,7 +622,7 @@ public final class MinecraftReflection {
 	 * @throws IllegalStateException If the class could not be found or deduced.
 	 */
 	public static Class<?> getChatSerializerClass() {
-		return getMinecraftClass("network.chat.IChatBaseComponent$ChatSerializer", "IChatBaseComponent$ChatSerializer");
+		return getMinecraftClass("network.chat.IChatBaseComponent$ChatSerializer", "network.chat.Component$Serializer", "IChatBaseComponent$ChatSerializer");
 	}
 
 	/**
@@ -631,7 +631,7 @@ public final class MinecraftReflection {
 	 * @return The ServerPing class.
 	 */
 	public static Class<?> getServerPingClass() {
-		return getMinecraftClass("network.protocol.status.ServerPing", "ServerPing");
+		return getMinecraftClass("network.protocol.status.ServerPing", "network.protocol.status.ServerStatus", "ServerPing");
 	}
 
 	/**
@@ -640,7 +640,7 @@ public final class MinecraftReflection {
 	 * @return The ServerPingServerData class.
 	 */
 	public static Class<?> getServerPingServerDataClass() {
-		return getMinecraftClass("network.protocol.status.ServerPing$ServerData", "ServerPing$ServerData");
+		return getMinecraftClass("network.protocol.status.ServerPing$ServerData", "network.protocol.status.ServerStatus$Version", "ServerPing$ServerData");
 	}
 
 	/**
@@ -651,6 +651,7 @@ public final class MinecraftReflection {
 	public static Class<?> getServerPingPlayerSampleClass() {
 		return getMinecraftClass(
 				"network.protocol.status.ServerPing$ServerPingPlayerSample",
+				"network.protocol.status.ServerStatus$Players",
 				"ServerPing$ServerPingPlayerSample");
 	}
 
@@ -677,7 +678,7 @@ public final class MinecraftReflection {
 	 * @return The statistics class.
 	 */
 	public static Class<?> getStatisticClass() {
-		return getMinecraftClass("stats.Statistic", "Statistic");
+		return getMinecraftClass("stats.Statistic", "stats.Stat", "Statistic");
 	}
 
 	/**
@@ -686,7 +687,7 @@ public final class MinecraftReflection {
 	 * @return The statistic list class.
 	 */
 	public static Class<?> getStatisticListClass() {
-		return getMinecraftClass("stats.StatisticList", "StatisticList");
+		return getMinecraftClass("stats.StatisticList", "stats.Stats", "StatisticList");
 	}
 
 	/**
@@ -712,7 +713,7 @@ public final class MinecraftReflection {
 	 * @return The PlayerConnection class.
 	 */
 	public static Class<?> getPlayerConnectionClass() {
-		return getMinecraftClass("server.network.PlayerConnection", "PlayerConnection");
+		return getMinecraftClass("server.network.PlayerConnection", "server.network.ServerGamePacketListenerImpl", "PlayerConnection");
 	}
 
 	/**
@@ -721,7 +722,7 @@ public final class MinecraftReflection {
 	 * @return The NetworkManager class.
 	 */
 	public static Class<?> getNetworkManagerClass() {
-		return getMinecraftClass("network.NetworkManager", "NetworkManager");
+		return getMinecraftClass("network.NetworkManager", "network.Connection", "NetworkManager");
 	}
 
 	/**
@@ -754,11 +755,11 @@ public final class MinecraftReflection {
 	}
 
 	public static Class<?> getFluidTypeClass() {
-		return getNullableNMS("world.level.material.FluidType", "FluidType");
+		return getNullableNMS("world.level.material.FluidType", "world.level.material.Fluid", "FluidType");
 	}
 
 	public static Class<?> getParticleTypeClass() {
-		return getNullableNMS("core.particles.ParticleType", "ParticleType");
+		return getNullableNMS("core.particles.ParticleType", "core.particles.SimpleParticleType", "ParticleType");
 	}
 
 	/**
@@ -776,7 +777,7 @@ public final class MinecraftReflection {
 	 * @return The DataWatcher class.
 	 */
 	public static Class<?> getDataWatcherClass() {
-		return getMinecraftClass("network.syncher.DataWatcher", "DataWatcher");
+		return getMinecraftClass("network.syncher.DataWatcher", "network.syncher.SynchedEntityData", "DataWatcher");
 	}
 
 	/**
@@ -785,7 +786,7 @@ public final class MinecraftReflection {
 	 * @return The BlockPosition class.
 	 */
 	public static Class<?> getBlockPositionClass() {
-		return getMinecraftClass("core.BlockPosition", "BlockPosition");
+		return getMinecraftClass("core.BlockPosition", "core.BlockPos", "BlockPosition");
 	}
 
 	/**
@@ -794,7 +795,7 @@ public final class MinecraftReflection {
 	 * @return The Vec3D class.
 	 */
 	public static Class<?> getVec3DClass() {
-		return getMinecraftClass("world.phys.Vec3D", "Vec3D");
+		return getMinecraftClass("world.phys.Vec3D", "world.phys.Vec3", "Vec3D");
 	}
 
 	/**
@@ -803,7 +804,7 @@ public final class MinecraftReflection {
 	 * @return The ChunkCoordIntPair class.
 	 */
 	public static Class<?> getChunkCoordIntPair() {
-		return getMinecraftClass("world.level.ChunkCoordIntPair", "ChunkCoordIntPair");
+		return getMinecraftClass("world.level.ChunkCoordIntPair", "world.level.ChunkPos", "ChunkCoordIntPair");
 	}
 
 	/**
@@ -812,11 +813,11 @@ public final class MinecraftReflection {
 	 * @return The class
 	 */
 	public static Class<?> getDataWatcherItemClass() {
-		return getMinecraftClass("network.syncher.DataWatcher$Item", "DataWatcher$Item", "DataWatcher$WatchableObject");
+		return getMinecraftClass("network.syncher.DataWatcher$Item", "network.syncher.SynchedEntityData$DataItem", "DataWatcher$Item", "DataWatcher$WatchableObject");
 	}
 
 	public static Class<?> getDataWatcherObjectClass() {
-		return getNullableNMS("network.syncher.DataWatcherObject", "DataWatcherObject");
+		return getNullableNMS("network.syncher.DataWatcherObject", "network.syncher.EntityDataAccessor", "DataWatcherObject");
 	}
 
 	public static boolean watcherObjectExists() {
@@ -828,23 +829,23 @@ public final class MinecraftReflection {
 	}
 
 	public static Class<?> getDataWatcherSerializerClass() {
-		return getNullableNMS("network.syncher.DataWatcherSerializer", "DataWatcherSerializer");
+		return getNullableNMS("network.syncher.DataWatcherSerializer", "network.syncher.EntityDataSerializer", "DataWatcherSerializer");
 	}
 
 	public static Class<?> getDataWatcherRegistryClass() {
-		return getMinecraftClass("network.syncher.DataWatcherRegistry", "DataWatcherRegistry");
+		return getMinecraftClass("network.syncher.DataWatcherRegistry", "network.syncher.EntityDataSerializers", "DataWatcherRegistry");
 	}
 
 	public static Class<?> getMinecraftKeyClass() {
-		return getMinecraftClass("resources.MinecraftKey", "MinecraftKey");
+		return getMinecraftClass("resources.MinecraftKey", "resources.ResourceLocation", "MinecraftKey");
 	}
 
 	public static Class<?> getMobEffectListClass() {
-		return getMinecraftClass("world.effect.MobEffectList", "MobEffectList");
+		return getMinecraftClass("world.effect.MobEffectList", "world.effect.MobEffect", "MobEffectList");
 	}
 
 	public static Class<?> getSoundEffectClass() {
-		return getNullableNMS("sounds.SoundEffect", "SoundEffect");
+		return getNullableNMS("sounds.SoundEffect", "sounds.SoundEvent", "SoundEffect");
 	}
 
 	/**
@@ -853,7 +854,7 @@ public final class MinecraftReflection {
 	 * @return The ServerConnection class.
 	 */
 	public static Class<?> getServerConnectionClass() {
-		return getMinecraftClass("server.network.ServerConnection", "ServerConnection");
+		return getMinecraftClass("server.network.ServerConnection", "server.network.ServerConnectionListener", "ServerConnection");
 	}
 
 	/**
@@ -862,7 +863,7 @@ public final class MinecraftReflection {
 	 * @return The NBT base class.
 	 */
 	public static Class<?> getNBTBaseClass() {
-		return getMinecraftClass("nbt.NBTBase", "NBTBase");
+		return getMinecraftClass("nbt.NBTBase", "nbt.Tag", "NBTBase");
 	}
 
 	/**
@@ -871,7 +872,7 @@ public final class MinecraftReflection {
 	 * @return The NBT read limiter.
 	 */
 	public static Class<?> getNBTReadLimiterClass() {
-		return getMinecraftClass("nbt.NBTReadLimiter", "NBTReadLimiter");
+		return getMinecraftClass("nbt.NBTReadLimiter", "nbt.NbtAccounter", "NBTReadLimiter");
 	}
 
 	/**
@@ -880,7 +881,7 @@ public final class MinecraftReflection {
 	 * @return The NBT Compond class.
 	 */
 	public static Class<?> getNBTCompoundClass() {
-		return getMinecraftClass("nbt.NBTTagCompound", "NBTTagCompound");
+		return getMinecraftClass("nbt.NBTTagCompound", "nbt.CompoundTag", "NBTTagCompound");
 	}
 
 	/**
@@ -889,7 +890,7 @@ public final class MinecraftReflection {
 	 * @return EntityTracker class.
 	 */
 	public static Class<?> getEntityTrackerClass() {
-		return getMinecraftClass("server.level.PlayerChunkMap$EntityTracker", "EntityTracker");
+		return getMinecraftClass("server.level.PlayerChunkMap$EntityTracker", "server.level.ChunkMap$TrackedEntity", "EntityTracker");
 	}
 
 	/**
@@ -902,6 +903,7 @@ public final class MinecraftReflection {
 	public static Class<?> getAttributeSnapshotClass() {
 		return getMinecraftClass(
 				"network.protocol.game.PacketPlayOutUpdateAttributes$AttributeSnapshot",
+				"network.protocol.game.ClientboundUpdateAttributesPacket$AttributeSnapshot",
 				"AttributeSnapshot",
 				"PacketPlayOutUpdateAttributes$AttributeSnapshot");
 	}
@@ -930,7 +932,7 @@ public final class MinecraftReflection {
 	 * @return The mob effect class.
 	 */
 	public static Class<?> getMobEffectClass() {
-		return getMinecraftClass("world.effect.MobEffect", "MobEffect");
+		return getMinecraftClass("world.effect.MobEffect", "world.effect.MobEffectInstance", "MobEffect");
 	}
 
 	/**
@@ -939,7 +941,7 @@ public final class MinecraftReflection {
 	 * @return The data serializer class.
 	 */
 	public static Class<?> getPacketDataSerializerClass() {
-		return getMinecraftClass("network.PacketDataSerializer", "PacketDataSerializer");
+		return getMinecraftClass("network.PacketDataSerializer", "network.FriendlyByteBuf", "PacketDataSerializer");
 	}
 
 	/**
@@ -948,7 +950,7 @@ public final class MinecraftReflection {
 	 * @return The NBTCompressedStreamTools class.
 	 */
 	public static Class<?> getNbtCompressedStreamToolsClass() {
-		return getMinecraftClass("nbt.NBTCompressedStreamTools", "NBTCompressedStreamTools");
+		return getMinecraftClass("nbt.NBTCompressedStreamTools", "nbt.NbtIo", "NBTCompressedStreamTools");
 	}
 
 	/**
@@ -957,7 +959,7 @@ public final class MinecraftReflection {
 	 * @return The tile entity class.
 	 */
 	public static Class<?> getTileEntityClass() {
-		return getMinecraftClass("world.level.block.entity.TileEntity", "TileEntity");
+		return getMinecraftClass("world.level.block.entity.TileEntity", "world.level.block.entity.BlockEntity", "TileEntity");
 	}
 
 	/**
@@ -1045,6 +1047,7 @@ public final class MinecraftReflection {
 	public static Class<?> getPlayerInfoDataClass() {
 		return getMinecraftClass(
 				"network.protocol.game.PacketPlayOutPlayerInfo$PlayerInfoData",
+				"network.protocol.game.ClientboundPlayerInfoPacket$PlayerUpdate",
 				"PacketPlayOutPlayerInfo$PlayerInfoData", "PlayerInfoData");
 	}
 
@@ -1055,7 +1058,12 @@ public final class MinecraftReflection {
 	 */
 	public static Class<?> getEnumEntityUseActionClass() {
 		Class<?> packetClass = PacketType.Play.Client.USE_ENTITY.getPacketClass();
-		return FuzzyReflection.fromClass(packetClass, true).getFieldByType("^.*(EnumEntityUseAction)").getType();
+		FuzzyReflection fuzzyReflection = FuzzyReflection.fromClass(packetClass, true);
+		try {
+			return fuzzyReflection.getFieldByType("^.*(EnumEntityUseAction)").getType();
+		} catch (IllegalArgumentException ignored) {
+			return fuzzyReflection.getFieldByType("^.*(Action)").getType();
+		}
 	}
 
 	/**
@@ -1112,7 +1120,7 @@ public final class MinecraftReflection {
 	 * @return The IBlockData class
 	 */
 	public static Class<?> getIBlockDataClass() {
-		return getMinecraftClass("world.level.block.state.IBlockData", "IBlockData");
+		return getMinecraftClass("world.level.block.state.IBlockData", "world.level.block.state.BlockState", "IBlockData");
 	}
 
 	/**
@@ -1170,7 +1178,7 @@ public final class MinecraftReflection {
 	}
 
 	public static Class<?> getSectionPositionClass() {
-		return getMinecraftClass("core.SectionPosition", "SectionPosition");
+		return getMinecraftClass("core.SectionPosition", "core.SectionPos", "SectionPosition");
 	}
 
 	/**
@@ -1458,23 +1466,23 @@ public final class MinecraftReflection {
 	}
 
 	public static Class<?> getNbtTagTypes() {
-		return getMinecraftClass("nbt.NBTTagTypes", "NBTTagTypes");
+		return getMinecraftClass("nbt.NBTTagTypes", "nbt.TagTypes", "NBTTagTypes");
 	}
 
 	public static Class<?> getChatDeserializer() {
-		return getMinecraftClass("util.ChatDeserializer", "ChatDeserializer");
+		return getMinecraftClass("util.ChatDeserializer", "util.GsonHelper", "ChatDeserializer");
 	}
 
 	public static Class<?> getChatMutableComponentClass() {
-		return getMinecraftClass("network.chat.IChatMutableComponent");
+		return getMinecraftClass("network.chat.IChatMutableComponent", "network.chat.MutableComponent");
 	}
 
 	public static Class<?> getDimensionManager() {
-		return getMinecraftClass("world.level.dimension.DimensionManager", "DimensionManager");
+		return getMinecraftClass("world.level.dimension.DimensionManager", "world.level.dimension.DimensionType", "DimensionManager");
 	}
 
 	public static Class<?> getMerchantRecipeList() {
-		return getMinecraftClass("world.item.trading.MerchantRecipeList", "MerchantRecipeList");
+		return getMinecraftClass("world.item.trading.MerchantRecipeList", "world.item.trading.MerchantOffers", "MerchantRecipeList");
 	}
 
 	public static Class<?> getResourceKey() {
@@ -1482,31 +1490,31 @@ public final class MinecraftReflection {
 	}
 
 	public static Class<?> getEntityTypes() {
-		return getMinecraftClass("world.entity.EntityTypes", "EntityTypes");
+		return getMinecraftClass("world.entity.EntityTypes", "world.entity.EntityType", "EntityTypes");
 	}
 
 	public static Class<?> getParticleParam() {
-		return getMinecraftClass("core.particles.ParticleParam", "ParticleParam");
+		return getMinecraftClass("core.particles.ParticleParam", "core.particles.ParticleOptions", "ParticleParam");
 	}
 
 	public static Class<?> getSectionPosition() {
-		return getMinecraftClass("core.SectionPosition", "SectionPosition");
+		return getMinecraftClass("core.SectionPosition", "core.SectionPos", "SectionPosition");
 	}
 
 	public static Class<?> getChunkProviderServer() {
-		return getMinecraftClass("server.level.ChunkProviderServer", "ChunkProviderServer");
+		return getMinecraftClass("server.level.ChunkProviderServer", "server.level.ServerChunkCache", "ChunkProviderServer");
 	}
 
 	public static Class<?> getPlayerChunkMap() {
-		return getMinecraftClass("server.level.PlayerChunkMap", "PlayerChunkMap");
+		return getMinecraftClass("server.level.PlayerChunkMap", "server.level.ChunkMap", "PlayerChunkMap");
 	}
 
 	public static Class<?> getIRegistry() {
-		return getNullableNMS("core.IRegistry", "IRegistry");
+		return getNullableNMS("core.IRegistry", "core.Registry", "IRegistry");
 	}
 
 	public static Class<?> getAttributeBase() {
-		return getMinecraftClass("world.entity.ai.attributes.AttributeBase", "AttributeBase");
+		return getMinecraftClass("world.entity.ai.attributes.AttributeBase", "world.entity.ai.attributes.Attribute", "AttributeBase");
 	}
 
 	public static Class<?> getProfilePublicKeyClass() {
@@ -1517,7 +1525,7 @@ public final class MinecraftReflection {
         try {
             return getMinecraftClass("SaltedSignature");
         } catch (RuntimeException runtimeException) {
-	        Class<?> minecraftEncryption = getMinecraftClass("util.MinecraftEncryption", "MinecraftEncryption");
+	        Class<?> minecraftEncryption = getMinecraftClass("util.MinecraftEncryption", "util.Crypt", "MinecraftEncryption");
 	        FuzzyMethodContract constructorContract = FuzzyMethodContract.newBuilder()
 			        .parameterCount(2)
 			        .parameterExactType(Long.TYPE, 0)

--- a/src/main/java/com/comphenix/protocol/wrappers/AutoWrapper.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AutoWrapper.java
@@ -73,6 +73,10 @@ public class AutoWrapper<T> implements EquivalentConverter<T> {
 		return wrap(wrapperClass, MinecraftReflection.getMinecraftClass(nmsClassName));
 	}
 
+	public static <T> AutoWrapper<T> wrap(Class<T> wrapperClass, String nmsClassName, String... aliases) {
+		return wrap(wrapperClass, MinecraftReflection.getMinecraftClass(nmsClassName, aliases));
+	}
+
 	public AutoWrapper<T> field(int index, Function<Object, Object> wrapper, Function<Object, Object> unwrapper) {
 		wrappers.put(index, wrapper);
 		unwrappers.put(index, unwrapper);

--- a/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
@@ -1627,7 +1627,7 @@ public class BukkitConverters {
 			public List<MerchantRecipe> getSpecific(Object generic) {
 				if (nmsMerchantRecipeToBukkit == null) {
 					Class<?> merchantRecipeClass = MinecraftReflection.getMinecraftClass(
-							"world.item.trading.MerchantRecipe","MerchantRecipe"
+							"world.item.trading.MerchantRecipe", "world.item.trading.MerchantOffer","MerchantRecipe"
 					);
 					FuzzyReflection reflection = FuzzyReflection.fromClass(merchantRecipeClass, false);
 					nmsMerchantRecipeToBukkit = Accessors.getMethodAccessor(reflection.getMethodByName("asBukkit"));

--- a/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
@@ -502,14 +502,14 @@ public abstract class EnumWrappers {
 
 		try {
 			// TODO enum names are more stable than their packet associations
-			ITEM_SLOT_CLASS = MinecraftReflection.getMinecraftClass("world.entity.EnumItemSlot", "EnumItemSlot");
+			ITEM_SLOT_CLASS = MinecraftReflection.getMinecraftClass("world.entity.EnumItemSlot", "world.entity.EquipmentSlot", "EnumItemSlot");
 		} catch (Exception ex) {
 			ITEM_SLOT_CLASS = getEnum(PacketType.Play.Server.ENTITY_EQUIPMENT.getPacketClass(), 0);
 		}
 
 		// In 1.17 the hand and use action class is no longer a field in the packet
 		if (MinecraftVersion.CAVES_CLIFFS_1.atOrAbove()) {
-			HAND_CLASS = MinecraftReflection.getMinecraftClass("world.EnumHand");
+			HAND_CLASS = MinecraftReflection.getMinecraftClass("world.EnumHand", "world.InteractionHand");
 			// class is named 'b' in the packet but class order differs in spigot and paper so we can only use the first method's return type (safest way)
 			ENTITY_USE_ACTION_CLASS = MinecraftReflection.getEnumEntityUseActionClass().getMethods()[0].getReturnType();
 		} else {
@@ -519,13 +519,13 @@ public abstract class EnumWrappers {
 
 		// 1.19 removed the entity spawn packet and moved the direction into a seperated class
 		if (MinecraftVersion.WILD_UPDATE.atOrAbove()) {
-			DIRECTION_CLASS = MinecraftReflection.getMinecraftClass("core.EnumDirection");
+			DIRECTION_CLASS = MinecraftReflection.getMinecraftClass("core.EnumDirection", "core.Direction");
 		} else {
 			DIRECTION_CLASS = getEnum(PacketType.Play.Server.SPAWN_ENTITY_PAINTING.getPacketClass(), 0);
 		}
 
 		CHAT_TYPE_CLASS = getEnum(PacketType.Play.Server.CHAT.getPacketClass(), 0);
-		ENTITY_POSE_CLASS = MinecraftReflection.getNullableNMS("world.entity.EntityPose", "EntityPose");
+		ENTITY_POSE_CLASS = MinecraftReflection.getNullableNMS("world.entity.EntityPose", "world.entity.Pose", "EntityPose");
 
 		associate(PROTOCOL_CLASS, Protocol.class, getProtocolConverter());
 		associate(CLIENT_COMMAND_CLASS, ClientCommand.class, getClientCommandConverter());

--- a/src/main/java/com/comphenix/protocol/wrappers/MovingObjectPositionBlock.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/MovingObjectPositionBlock.java
@@ -11,7 +11,7 @@ import org.bukkit.util.Vector;
 
 public class MovingObjectPositionBlock implements Cloneable {
 	private static final Class<?> NMS_CLASS = MinecraftReflection.getNullableNMS(
-			"world.phys.MovingObjectPositionBlock", "MovingObjectPositionBlock");
+			"world.phys.MovingObjectPositionBlock", "world.phys.BlockHitResult", "MovingObjectPositionBlock");
 
 	private BlockPosition position;
 	private Vector posVector;

--- a/src/main/java/com/comphenix/protocol/wrappers/Vector3F.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/Vector3F.java
@@ -83,7 +83,7 @@ public class Vector3F {
 	}
 
 	private static Constructor<?> constructor = null;
-	private static final Class<?> NMS_CLASS = MinecraftReflection.getNullableNMS("core.Vector3f","Vector3f");
+	private static final Class<?> NMS_CLASS = MinecraftReflection.getNullableNMS("core.Vector3f", "core.Rotations", "Vector3f");
 
 	public static Class<?> getMinecraftClass() {
 		return NMS_CLASS;

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedAttribute.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedAttribute.java
@@ -112,7 +112,7 @@ public class WrappedAttribute extends AbstractWrapper {
 	}
 
 	private static final Class<?> ATTRIBUTE_BASE_CLASS = MinecraftReflection.getNullableNMS(
-			"world.entity.ai.attributes.AttributeBase", "AttributeBase"
+			"world.entity.ai.attributes.AttributeBase", "world.entity.ai.attributes.Attribute", "AttributeBase"
 	);
 
 	private static final AutoWrapper<WrappedAttributeBase> ATTRIBUTE_BASE = AutoWrapper.wrap(

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedDataWatcher.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedDataWatcher.java
@@ -130,7 +130,7 @@ public class WrappedDataWatcher extends AbstractWrapper implements Iterable<Wrap
 		// Mojang added difficulty to lightning strikes, so this'll have to do
 		if (eggConstructor == null) {
 			eggConstructor = Accessors.getConstructorAccessor(
-					MinecraftReflection.getMinecraftClass("world.entity.projectile.EntityEgg", "EntityEgg"),
+					MinecraftReflection.getMinecraftClass("world.entity.projectile.EntityEgg", "world.entity.projectile.ThrownEgg", "EntityEgg"),
 					MinecraftReflection.getNmsWorldClass(), double.class, double.class, double.class
 			);
 		}

--- a/src/test/java/com/comphenix/protocol/wrappers/AutoWrapperTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/AutoWrapperTest.java
@@ -83,12 +83,12 @@ public class AutoWrapperTest {
 
   private AutoWrapper<WrappedAdvancementDisplay> displayWrapper() {
     return AutoWrapper
-        .wrap(WrappedAdvancementDisplay.class, "advancements.AdvancementDisplay")
+        .wrap(WrappedAdvancementDisplay.class, "advancements.AdvancementDisplay", "advancements.DisplayInfo")
         .field(0, BukkitConverters.getWrappedChatComponentConverter())
         .field(1, BukkitConverters.getWrappedChatComponentConverter())
         .field(2, BukkitConverters.getItemStackConverter())
         .field(3, MinecraftKey.getConverter())
-        .field(4, EnumWrappers.getGenericConverter(getMinecraftClass("advancements.AdvancementFrameType"),
+        .field(4, EnumWrappers.getGenericConverter(getMinecraftClass("advancements.AdvancementFrameType", "advancements.FrameType"),
             WrappedFrameType.class));
   }
 


### PR DESCRIPTION
I've gone through most reflective class calls to support fully Mojang mapped class names. Packet types already did, but everything else didn't, so here's the rest in an attempt to make PL not fall off a cliff once more people use proper mappings at runtime (which Paper for example already offers in their downloads API and which will at some point be retreivable from the main downloads page).

Done using https://nms.screamingsandals.org/1.19.2/ and by looking at properly mapped decompiled sources, which the easiest way of doing is by just cloning Paper and applying patches with one command.

Not *fully* done, hence just a draft, but I'd still like some feedback/to hear whether this is something that'll get merged.