### PR TITLE
Fix not being able to read effects from RemoveEntityEffect packet

### DIFF
--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -867,7 +867,7 @@ public final class MinecraftReflection {
 	}
 
 	public static Class<?> getMobEffectListClass() {
-		return getMinecraftClass("world.effect.MobEffectList", "world.effect.MobEffect", "MobEffectList");
+		return getMinecraftClass("world.effect.MobEffectList", "MobEffectList", "world.effect.MobEffect");
 	}
 
 	public static Class<?> getSoundEffectClass() {


### PR DESCRIPTION
The issue was that the Mojang Mapped Server support PR broke the ability to read potion effects from the RemoveEntityEffect packet due to `world.effect.MobEffect` also existing in the non mojang-mapped servers but with different functonality.
This PR fixes the issue mentioned in #1907.