### PR TITLE
Improve performance by removing hash computations of packets

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -539,8 +539,10 @@ public class NettyChannelInjector implements Injector {
 		}
 
 		// filter out all packets which were explicitly send to not be processed by any event
-		NetworkMarker marker = this.savedMarkers.remove(packet);
-		if (this.skippedPackets.remove(packet)) {
+		// pre-checking isEmpty will reduce the need of hashing packets which don't override the
+		// hashCode method; this presents calls to the very slow identityHashCode default implementation
+		NetworkMarker marker = this.savedMarkers.isEmpty() ? null : this.savedMarkers.remove(packet);
+		if (!this.skippedPackets.isEmpty() && this.skippedPackets.remove(packet)) {
 			// if a marker was set there might be scheduled packets to execute after the packet send
 			// for this to work we need to proxy the input action to provide access to them
 			if (marker != null) {

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
@@ -33,13 +34,11 @@ import com.comphenix.protocol.utility.MinecraftProtocolVersion;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.utility.MinecraftVersion;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
-import com.google.common.collect.MapMaker;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
-import jdk.internal.misc.TerminatingThreadLocal;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 
@@ -101,8 +100,8 @@ public class NettyChannelInjector implements Injector {
 	private final FieldAccessor channelField;
 
 	// packet marking
+	private final Map<Object, NetworkMarker> savedMarkers = new WeakHashMap<>(16, 0.9f);
 	private final Set<Object> skippedPackets = Collections.synchronizedSet(new HashSet<>());
-	private final Map<Object, NetworkMarker> savedMarkers = new MapMaker().weakKeys().makeMap();
 	protected final ThreadLocal<Boolean> processedPackets = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
 	// status of this injector


### PR DESCRIPTION
This PR removes most of the hash computations for packets that are done when processing outbound packets. There are two changes for that:
* Removed the set which stores all packets which were processed by the outbound injector, indicating that state to the channel proxy. Each write to the set, and each read from it would cause a hash computation which in most cases is done via the slow default implementation (`System.identityHashCode`). This is now replaced by a ThreadLocal which indicates to the channel if on the current thread the packet was already processed (this works as the call to `write` or `writeAndFlush` has to be in the event loop). This uses Boolean.TRUE and .FALSE to prevent un-/boxing to/from the primitive type.
* Added a check for the emptiness of `savedMarkers` and `skippedPackets` before reading from it. This check is way cheaper, as it only access a field which holds the size.

Closes #1915 