### PR TITLE
Fix getEntityClass full qualifier

### DIFF
--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -540,7 +540,7 @@ public final class MinecraftReflection {
 	 */
 	public static Class<?> getEntityClass() {
 		try {
-			return getMinecraftClass("server.level.Entity", "server.level.ServerEntity", "Entity");
+			return getMinecraftClass("world.entity.Entity", "Entity");
 		} catch (RuntimeException e) {
 			return fallbackMethodReturn("Entity", "entity.CraftEntity", "getHandle");
 		}


### PR DESCRIPTION
The previous `server.world.Entity` threw me off, so this replacement wasn't quite right either (but was still saved by the last aliases/fallback).