### PR TITLE
Update bytebuddy, add tab completion for PacketLogging command and use cache for getFieldAccessor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
 		<dependency>
 			<groupId>net.bytebuddy</groupId>
 			<artifactId>byte-buddy</artifactId>
-			<version>1.12.12</version>
+			<version>1.12.18</version>
 		</dependency>
 
 		<!-- Testing dependencies -->

--- a/src/main/java/com/comphenix/protocol/PacketLogging.java
+++ b/src/main/java/com/comphenix/protocol/PacketLogging.java
@@ -144,9 +144,7 @@ public class PacketLogging implements TabExecutor, PacketListener {
 						receivingTypes.add(type);
 					}
 				} else {
-					if (sendingTypes.contains(type)) {
-						sendingTypes.remove(type);
-					} else {
+					if (!sendingTypes.remove(type)) {
 						sendingTypes.add(type);
 					}
 				}

--- a/src/main/java/com/comphenix/protocol/PacketType.java
+++ b/src/main/java/com/comphenix/protocol/PacketType.java
@@ -707,7 +707,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 	 * Retrieve the current packet/legacy lookup.
 	 * @return The packet type lookup.
 	 */
-	private static PacketTypeLookup getLookup() {
+	public static PacketTypeLookup getLookup() {
 		if (LOOKUP == null) {
 			LOOKUP = new PacketTypeLookup().
 				addPacketTypes(Handshake.Client.getInstance()).

--- a/src/main/java/com/comphenix/protocol/PacketTypeLookup.java
+++ b/src/main/java/com/comphenix/protocol/PacketTypeLookup.java
@@ -1,8 +1,6 @@
 package com.comphenix.protocol;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.comphenix.protocol.PacketType.Protocol;
@@ -174,4 +172,9 @@ class PacketTypeLookup {
 	public ClassLookup getClassLookup() {
 		return classLookup;
 	}
+
+	public Collection<PacketType> getAllClassNames(Protocol protocol, Sender sender) {
+		return classLookup.getMap(protocol, sender).values();
+	}
+
 }

--- a/src/main/java/com/comphenix/protocol/ProtocolLib.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLib.java
@@ -47,6 +47,8 @@ import java.util.regex.Pattern;
 import org.bukkit.Server;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.command.TabExecutor;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -332,6 +334,7 @@ public class ProtocolLib extends JavaPlugin {
 			this.registerCommand(CommandFilter.NAME, this.commandFilter);
 			this.registerCommand(PacketLogging.NAME, this.packetLogging);
 
+
 			// Player login and logout events
 			protocolManager.registerEvents(manager, this);
 
@@ -462,11 +465,16 @@ public class ProtocolLib extends JavaPlugin {
 				return;
 			}
 
-			PluginCommand command = this.getCommand(name);
+			final PluginCommand command = this.getCommand(name);
 
 			// Try to load the command
 			if (command != null) {
+
 				command.setExecutor(executor);
+
+				if (executor instanceof TabCompleter) {
+					command.setTabCompleter((TabExecutor) executor);
+				}
 			} else {
 				throw new RuntimeException("plugin.yml might be corrupt.");
 			}

--- a/src/main/java/com/comphenix/protocol/collections/ExpireHashMap.java
+++ b/src/main/java/com/comphenix/protocol/collections/ExpireHashMap.java
@@ -4,8 +4,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Objects;
@@ -49,7 +49,7 @@ public class ExpireHashMap<K, V> {
 	}
 	
 	private final Map<K, ExpireEntry> keyLookup = new HashMap<>();
-	private final PriorityQueue<ExpireEntry> expireQueue =  new PriorityQueue<>();
+	private final PriorityBlockingQueue<ExpireEntry> expireQueue =  new PriorityBlockingQueue<>();
 	
 	// View of keyLookup with direct values
 	private final Map<K, V> valueView = Maps.transformValues(keyLookup, entry -> entry.expireValue);

--- a/src/main/java/com/comphenix/protocol/reflect/accessors/MethodHandleHelper.java
+++ b/src/main/java/com/comphenix/protocol/reflect/accessors/MethodHandleHelper.java
@@ -1,7 +1,7 @@
 package com.comphenix.protocol.reflect.accessors;
 
 import com.comphenix.protocol.ProtocolLogger;
-import com.google.common.collect.MapMaker;
+import com.comphenix.protocol.collections.ExpireHashMap;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -12,8 +12,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 final class MethodHandleHelper {
@@ -21,7 +20,7 @@ final class MethodHandleHelper {
 	private static final Lookup LOOKUP;
 
 	// Field -> (MethodName -> Handle)
-	private static final Map<Field, EnumMap<FieldAccessorType, MethodHandle>> LOOKUP_CACHE = new HashMap<>();
+	private static final ExpireHashMap<Field, EnumMap<FieldAccessorType, MethodHandle>> LOOKUP_CACHE = new ExpireHashMap<>();
 
 	// static fields, converted as "public Object get()" and "public void set(Object value)"
 	private static final MethodType STATIC_FIELD_GETTER = MethodType.methodType(Object.class);
@@ -95,7 +94,7 @@ final class MethodHandleHelper {
 			EnumMap<FieldAccessorType, MethodHandle> cached = LOOKUP_CACHE.get(field);
 			if (cached == null) {
 				cached = new EnumMap<>(FieldAccessorType.class);
-				LOOKUP_CACHE.put(field, cached);
+				LOOKUP_CACHE.put(field, cached, 30, TimeUnit.MINUTES);
 			}
 
 			MethodHandle getter = cached.get(FieldAccessorType.GETTER);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ProtocolLib
 version: ${project.fullVersion}
 description: Provides read/write access to the Minecraft protocol.
-authors: [dmulloy2, comphenix]
+authors: [dmulloy2, comphenix, camdenorrb]
 
 main: com.comphenix.protocol.ProtocolLib
 load: STARTUP


### PR DESCRIPTION
- ByteBuddy seemed to be out of date so I updated it
- Packet logging command seemed a bit complex, so I added tab completion to make it easier to use
- `getFieldAccessor` seemed a bit slow on our production servers so I went ahead and added a timed cache for it.

While getFieldAccessor was using a cache, it seemed that the gc was clearing it frequently