### PR TITLE
Force login disconnect packet to be run async

### DIFF
--- a/src/main/java/com/comphenix/protocol/PacketType.java
+++ b/src/main/java/com/comphenix/protocol/PacketType.java
@@ -553,6 +553,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
 		public static class Server extends PacketTypeEnum {
 			private final static Sender SENDER = Sender.SERVER;
 
+			@ForceAsync
 			public static final PacketType DISCONNECT =                   new PacketType(PROTOCOL, SENDER, 0x00, "Disconnect", "SPacketDisconnect");
 			public static final PacketType ENCRYPTION_BEGIN =             new PacketType(PROTOCOL, SENDER, 0x01, "EncryptionBegin", "SPacketEncryptionRequest");
 			public static final PacketType SUCCESS =                      new PacketType(PROTOCOL, SENDER, 0x02, "Success", "SPacketLoginSuccess");


### PR DESCRIPTION
The login disconnect packet must be async, if it is not the packet is not sent to the player before they are disconnected from the server, meaning they get no kick reason. The listener will also never be called anyway if not async.

Closes https://github.com/dmulloy2/ProtocolLib/issues/2020