### PR TITLE
Added PacketContainer#getUUIDLists()

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -926,6 +926,12 @@ public abstract class AbstractStructure {
         );
     }
 
+    public StructureModifier<List<UUID>> getUUIDLists() {
+        return structureModifier.withType(
+                List.class,
+                BukkitConverters.getListConverter(Converters.passthrough(UUID.class)));
+    }
+
     /**
      * Retrieve a read/write structure for Instants in (mostly for use in 1.19+)
      * @return The Structure Modifier


### PR DESCRIPTION
The 1.19.3 PlayerListRemove is the first one using a List of UUIDs.

Fixed https://github.com/dmulloy2/ProtocolLib/issues/2048