### PR TITLE
Fix SynchedEntityData$DataValue mapping

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedDataValue.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedDataValue.java
@@ -12,7 +12,7 @@ import com.comphenix.protocol.wrappers.WrappedDataWatcher.Serializer;
  */
 public class WrappedDataValue extends AbstractWrapper {
 
-	private static final Class<?> HANDLE_TYPE = MinecraftReflection.getMinecraftClass("network.syncher.DataWatcher$b");
+	private static final Class<?> HANDLE_TYPE = MinecraftReflection.getMinecraftClass("network.syncher.DataWatcher$b", "network.syncher.SynchedEntityData$DataValue");
 
 	private static ConstructorAccessor constructor;
 


### PR DESCRIPTION
I don't know why Spigot's decompiler doesn't handle inner class name, but here's the proper one on mapped servers