### PR TITLE
Fixed backwards compatibility with WrappedDataValue

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedDataValue.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedDataValue.java
@@ -12,7 +12,7 @@ import com.comphenix.protocol.wrappers.WrappedDataWatcher.Serializer;
  */
 public class WrappedDataValue extends AbstractWrapper {
 
-	private static final Class<?> HANDLE_TYPE = MinecraftReflection.getMinecraftClass("network.syncher.DataWatcher$b", "network.syncher.SynchedEntityData$DataValue");
+	private static final Class<?> HANDLE_TYPE = MinecraftReflection.getNullableNMS("network.syncher.DataWatcher$b", "network.syncher.SynchedEntityData$DataValue");
 
 	private static ConstructorAccessor constructor;
 


### PR DESCRIPTION
When running on older versions with latest build of ProtocoLib, the server would throw ExceptionInInitializerError, because of unwrapped getMinecraftClass method call would throw RuntimeException