### PR TITLE
Minor Performance Improvement

### DIFF
--- a/src/main/java/com/comphenix/protocol/concurrency/PacketTypeSet.java
+++ b/src/main/java/com/comphenix/protocol/concurrency/PacketTypeSet.java
@@ -17,13 +17,13 @@ public class PacketTypeSet {
 	private final Set<Class<?>> classes;
 
 	public PacketTypeSet() {
-		this.types = new HashSet<>(16, 0.5f);
-		this.classes = new HashSet<>(16, 0.5f);
+		this.types = new HashSet<>(16, 0.9f);
+		this.classes = new HashSet<>(16, 0.9f);
 	}
 
 	public PacketTypeSet(Collection<? extends PacketType> values) {
-		this.types = new HashSet<>(values.size(), 0.5f);
-		this.classes = new HashSet<>(values.size(), 0.5f);
+		this.types = new HashSet<>(values.size(), 0.9f);
+		this.classes = new HashSet<>(values.size(), 0.9f);
 
 		this.addAll(values);
 	}

--- a/src/main/java/com/comphenix/protocol/concurrency/PacketTypeSet.java
+++ b/src/main/java/com/comphenix/protocol/concurrency/PacketTypeSet.java
@@ -17,13 +17,13 @@ public class PacketTypeSet {
 	private final Set<Class<?>> classes;
 
 	public PacketTypeSet() {
-		this.types = new HashSet<>(16, 0.9f);
-		this.classes = new HashSet<>(16, 0.9f);
+		this.types = new HashSet<>(16, 0.5f);
+		this.classes = new HashSet<>(16, 0.5f);
 	}
 
 	public PacketTypeSet(Collection<? extends PacketType> values) {
-		this.types = new HashSet<>(values.size(), 0.9f);
-		this.classes = new HashSet<>(values.size(), 0.9f);
+		this.types = new HashSet<>(values.size(), 0.5f);
+		this.classes = new HashSet<>(values.size(), 0.5f);
 
 		this.addAll(values);
 	}

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -101,7 +101,7 @@ public class NettyChannelInjector implements Injector {
 
 	// packet marking
 	private final Map<Object, NetworkMarker> savedMarkers = new WeakHashMap<>(16, 0.9f);
-	private final Set<Object> skippedPackets = Collections.synchronizedSet(new HashSet<>());
+	private final Set<Object> skippedPackets = ConcurrentHashMap.newKeySet();
 	protected final ThreadLocal<Boolean> processedPackets = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
 	// status of this injector


### PR DESCRIPTION
Changed the `skippedPackets` set in NettyChannelInjector to use a ConcurrentHashMap as the underlying hashmap. This is because ConcurrentHashMap are able to perform most read operations with out having to lock the entire map.

Profiles using spark on my server with 80+ players showed that the call Collections$SynchronizedCollection.isEmpty() (which was performed on the `skippedPackets` set) was a considerable bottleneck taking 0.88% of the tick. Following this change, the isEmpty call is fast enough to no longer show up on profiles.