### PR TITLE
Fix listeners removing each other

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/injector/PacketFilterManager.java
@@ -306,6 +306,10 @@ public class PacketFilterManager implements ListenerInvoker, InternalManager {
 			ListeningWhitelist outbound = listener.getSendingWhitelist();
 			ListeningWhitelist inbound = listener.getReceivingWhitelist();
 
+			// Remove packets from the lists if they are not supposed to be in those lists
+			inbound.getTypes().removeIf(type -> !type.isClient());
+			outbound.getTypes().removeIf(type -> !type.isServer());
+
 			// verify plugin if needed
 			if (this.shouldVerifyPlugin(outbound, inbound)) {
 				this.printPluginWarnings(listener.getPlugin());


### PR DESCRIPTION
There's a nasty little bug where there's no sanity checking on what types of packets can be registered for incoming and outgoing whitelists. This means that another check fails in removePacketListener where it'll successfully remove your outgoing packet, because nothing is listening to it in the incoming.

Or to rephrase.
Libs Disguises listens for entity spawn.
AdvancedReplays listens for entity spawn and for the client to send its position.

Libs Disguises adds its listener.
AdvancedReplays adds its listener.
AdvancedReplays removes its listener.
The client packets are successfully stopped, and because Lib's Disguises did not register entity spawn in the incoming packets, entity spawn is no longer listened to either as ProtocolLib thinks no one is listening.

Because despite the existence of two whitelists, there's no sanity checking in what is valid, anywhere. But they both share the same deregistration code. So because Lib's Disguises doesn't add it as an incoming packet.. It gets hit.

Sorry if this is unreadable, had a headache trying to figure it out and its time for bed.