### PR TITLE
Draft: Implement packet filtering for bundled packets in 1.19.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.4.0</version>
+				<version>3.5.0</version>
 				<configuration>
 					<failOnError>false</failOnError>
 					<encoding>ISO-8859-1</encoding>

--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -1121,6 +1121,12 @@ public abstract class AbstractStructure {
         return structureModifier.withType(Optional.class, Converters.optional(converter));
     }
 
+    public StructureModifier<Iterable<PacketContainer>> getPacketBundles() {
+        return structureModifier.withType(Iterable.class, Converters.iterable(
+            BukkitConverters.getPacketContainerConverter(), ArrayList::new, ArrayList::new
+        ));
+    }
+
     /**
      * Represents an equivalent converter for ItemStack arrays.
      * @author Kristian

--- a/src/main/java/com/comphenix/protocol/events/PacketEvent.java
+++ b/src/main/java/com/comphenix/protocol/events/PacketEvent.java
@@ -100,14 +100,14 @@ public class PacketEvent extends EventObject implements Cancellable {
 		this.bundle = bundleEvent;
 	}
 
-	private PacketEvent(PacketEvent origial, AsyncMarker asyncMarker) {
-		super(origial.source);
-		this.packet = origial.packet;
-		this.playerReference = origial.getPlayerReference();
-		this.cancel = origial.cancel;
-		this.serverPacket = origial.serverPacket;
-		this.filtered = origial.filtered;
-		this.networkMarker = origial.networkMarker;
+	private PacketEvent(PacketEvent original, AsyncMarker asyncMarker) {
+		super(original.source);
+		this.packet = original.packet;
+		this.playerReference = original.getPlayerReference();
+		this.cancel = original.cancel;
+		this.serverPacket = original.serverPacket;
+		this.filtered = original.filtered;
+		this.networkMarker = original.networkMarker;
 		this.asyncMarker = asyncMarker;
 		this.asynchronous = true;
 	}

--- a/src/main/java/com/comphenix/protocol/events/PacketEvent.java
+++ b/src/main/java/com/comphenix/protocol/events/PacketEvent.java
@@ -205,12 +205,12 @@ public class PacketEvent extends EventObject implements Cancellable {
 	 * @param packet    - the packet.
 	 * @param marker    - the network marker.
 	 * @param recipient - the client that will receieve the packet.
-	 * @param filtered  - whether or not this packet event is processed by every packet listener.
-	 * @param bundle    - The corresponding packet event of the bundle if this packet is part of a bundle.
+	 * @param filtered  - whether this packet event is processed by every packet listener.
+	 * @param bundle    - The corresponding packet event of the bundle if this packet is part of a bundle. Otherwise, null.
 	 * @return The event.
 	 */
 	public static PacketEvent fromServer(Object source, PacketContainer packet, NetworkMarker marker, Player recipient,
-			boolean filtered, PacketEvent bundle) {
+			boolean filtered, @Nullable PacketEvent bundle) {
 		return new PacketEvent(source, packet, marker, recipient, true, filtered, bundle);
 	}
 
@@ -542,8 +542,8 @@ public class PacketEvent extends EventObject implements Cancellable {
 	}
 
 	/**
-	 * Whether this packet is part of the bundle
-	 * @return Corresponding packet event
+	 * Returns the packet event corresponding to the bundle if this packet is sent as a part of a bundle, t. Otherwise, null.
+	 * @return Corresponding packet event or null.
 	 */
 	@Nullable
 	public PacketEvent getBundle() {

--- a/src/main/java/com/comphenix/protocol/injector/SortedPacketListenerList.java
+++ b/src/main/java/com/comphenix/protocol/injector/SortedPacketListenerList.java
@@ -148,7 +148,8 @@ public final class SortedPacketListenerList extends AbstractConcurrentListenerMu
 	 * @param priorityFilter - the piority for a listener to be invoked. If null is provided, every registered listener will be invoked
 	 */
 	public void invokePacketSending(ErrorReporter reporter, PacketEvent event, @Nullable ListenerPriority priorityFilter) {
-		if(event.getPacketType() == PacketType.Play.Server.DELIMITER) {
+		invokeUnpackedPacketSending(reporter, event, priorityFilter);
+		if(event.getPacketType() == PacketType.Play.Server.DELIMITER && !event.isCancelled()) {
 			// unpack the bundle and invoke for each packet in the bundle
 			StructureModifier<Iterable> iterableModifier = event.getPacket().getSpecificModifier(Iterable.class);
 			Iterable packets = iterableModifier.read(0);
@@ -168,8 +169,6 @@ public final class SortedPacketListenerList extends AbstractConcurrentListenerMu
 			} else {
 				event.setCancelled(true); // cancel packet if each individual packet has been canceled
 			}
-		} else {
-			invokeUnpackedPacketSending(reporter, event, priorityFilter);
 		}
 	}
 

--- a/src/main/java/com/comphenix/protocol/injector/SortedPacketListenerList.java
+++ b/src/main/java/com/comphenix/protocol/injector/SortedPacketListenerList.java
@@ -155,7 +155,7 @@ public final class SortedPacketListenerList extends AbstractConcurrentListenerMu
 				PacketType packetType = PacketRegistry.getPacketType(handle.getClass());
 				PacketContainer container = new PacketContainer(packetType, handle);
 				PacketEvent packetEvent = PacketEvent.fromServer(this, container, event.getNetworkMarker(), event.getPlayer());
-				invokePacketSending(reporter, packetEvent, priorityFilter);
+				invokeUnpackedPacketSending(reporter, packetEvent, priorityFilter);
 
 				if(packetEvent.isCancelled()) {
 					iterator.remove();

--- a/src/main/java/com/comphenix/protocol/injector/StructureCache.java
+++ b/src/main/java/com/comphenix/protocol/injector/StructureCache.java
@@ -135,6 +135,11 @@ public class StructureCache {
 
 		return STRUCTURE_MODIFIER_CACHE.computeIfAbsent(packetType, type -> {
 			Class<?> packetClass = PacketRegistry.getPacketClassFromType(type);
+
+			// We need to map the Bundle Delimiter to the synthetic bundle packet which contains a list of all packets in a bundle
+			if(MinecraftVersion.atOrAbove(MinecraftVersion.FEATURE_PREVIEW_2) && packetClass.equals(MinecraftReflection.getBundleDelimiterClass())) {
+				packetClass = MinecraftReflection.getPackedBundlePacketClass();
+			}
 			return new StructureModifier<>(packetClass, MinecraftReflection.getPacketClass(), true);
 		});
 	}

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -27,12 +27,7 @@ import com.comphenix.protocol.reflect.FuzzyReflection;
 import com.comphenix.protocol.reflect.accessors.Accessors;
 import com.comphenix.protocol.reflect.accessors.FieldAccessor;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyFieldContract;
-import com.comphenix.protocol.utility.ByteBuddyGenerated;
-import com.comphenix.protocol.utility.MinecraftFields;
-import com.comphenix.protocol.utility.MinecraftMethods;
-import com.comphenix.protocol.utility.MinecraftProtocolVersion;
-import com.comphenix.protocol.utility.MinecraftReflection;
-import com.comphenix.protocol.utility.MinecraftVersion;
+import com.comphenix.protocol.utility.*;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -558,7 +553,7 @@ public class NettyChannelInjector implements Injector {
 		}
 
 		// no listener and no marker - no magic :)
-		if (!this.channelListener.hasListener(packet.getClass()) && marker == null) {
+		if (!this.channelListener.hasListener(packet.getClass()) && marker == null && !Util.isBundlePacket(packet.getClass())) {
 			return action;
 		}
 

--- a/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerInjector.java
@@ -28,6 +28,7 @@ import com.comphenix.protocol.reflect.accessors.FieldAccessor;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyFieldContract;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyMethodContract;
 import com.comphenix.protocol.utility.MinecraftReflection;
+import com.comphenix.protocol.utility.Util;
 import com.comphenix.protocol.wrappers.Pair;
 import io.netty.channel.ChannelFuture;
 import org.bukkit.Server;
@@ -90,7 +91,7 @@ public class NetworkManagerInjector implements ChannelListener {
 	public PacketEvent onPacketSending(Injector injector, Object packet, NetworkMarker marker) {
 		// check if we need to intercept the packet
 		Class<?> packetClass = packet.getClass();
-		if (this.outboundListeners.contains(packetClass) || marker != null) {
+		if (this.outboundListeners.contains(packetClass) || marker != null || Util.isBundlePacket(packetClass)) {
 			// wrap packet and construct the event
 			PacketContainer container = new PacketContainer(PacketRegistry.getPacketType(packetClass), packet);
 			PacketEvent packetEvent = PacketEvent.fromServer(this, container, marker, injector.getPlayer());

--- a/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
@@ -30,6 +30,7 @@ import com.comphenix.protocol.reflect.StructureModifier;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyFieldContract;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.utility.MinecraftVersion;
+import com.comphenix.protocol.utility.Util;
 
 /**
  * Static packet registry in Minecraft.
@@ -382,6 +383,9 @@ public class PacketRegistry {
 	 * @return The packet type, or NULL if not found.
 	 */
 	public static PacketType getPacketType(Class<?> packet) {
+		if(Util.isBundlePacket(packet)) {
+			return PacketType.Play.Server.DELIMITER;
+		}
 		initialize();
 		return REGISTER.classToType.get(packet);
 	}

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -628,6 +628,14 @@ public final class MinecraftReflection {
 		return getMinecraftClass("network.chat.IChatBaseComponent", "network.chat.IChatbaseComponent", "network.chat.Component", "IChatBaseComponent");
 	}
 
+	public static Class<?> getPackedBundlePacketClass() {
+		return getMinecraftClass("network.protocol.game.ClientboundBundlePacket", "ClientboundBundlePacket");
+	}
+
+	public static Class<?> getBundleDelimiterClass() {
+		return getMinecraftClass("network.protocol.BundleDelimiterPacket","BundleDelimiterPacket");
+	}
+
 	public static Class<?> getIChatBaseComponentArrayClass() {
 		return getArrayClass(getIChatBaseComponentClass());
 	}

--- a/src/main/java/com/comphenix/protocol/utility/Util.java
+++ b/src/main/java/com/comphenix/protocol/utility/Util.java
@@ -22,6 +22,7 @@ package com.comphenix.protocol.utility;
 public final class Util {
 
 	private static final boolean SPIGOT = classExists("org.spigotmc.SpigotConfig");
+	private static Class<?> cachedBundleClass;
 
 	public static boolean classExists(String className) {
 		try {
@@ -58,5 +59,15 @@ public final class Util {
 			}
 		}
 		return false;
+	}
+
+	public static boolean isBundlePacket(Class<?> packetClass) {
+		if(!MinecraftVersion.atOrAbove(MinecraftVersion.FEATURE_PREVIEW_2)) {
+			return false;
+		}
+		if(cachedBundleClass == null) {
+			cachedBundleClass = MinecraftReflection.getPackedBundlePacketClass();
+		}
+		return packetClass.equals(cachedBundleClass);
 	}
 }

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -40,7 +40,7 @@ public class AdventureComponentConverter {
 
  	/**
 	 * Converts a {@link Component} into a ProtocolLib wrapper
-	 * @param components Component
+	 * @param component Component
 	 * @return ProtocolLib wrapper
 	 */
   	public static WrappedChatComponent fromComponent(Component component) {

--- a/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
@@ -16,6 +16,7 @@
  */
 package com.comphenix.protocol.wrappers;
 
+import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.Either.Left;
 import com.comphenix.protocol.wrappers.Either.Right;
 import com.comphenix.protocol.wrappers.WrappedProfilePublicKey.WrappedProfileKeyData;
@@ -616,6 +617,10 @@ public class BukkitConverters {
 
 	public static EquivalentConverter<WrappedLevelChunkData.LightData> getWrappedLightDataConverter() {
 		return ignoreNull(handle(WrappedLevelChunkData.LightData::getHandle, WrappedLevelChunkData.LightData::new, WrappedLevelChunkData.LightData.class));
+	}
+
+	public static EquivalentConverter<PacketContainer> getPacketContainerConverter() {
+		return handle(PacketContainer::getHandle, PacketContainer::fromPacket, PacketContainer.class);
 	}
 
 	/**

--- a/src/test/java/com/comphenix/protocol/wrappers/BukkitConvertersTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/BukkitConvertersTest.java
@@ -4,9 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.comphenix.protocol.BukkitInitialization;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.reflect.EquivalentConverter;
 import com.comphenix.protocol.wrappers.Either.Left;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -55,4 +59,17 @@ public class BukkitConvertersTest {
         assertEquals(wrapped.left(), nmsEither.left());
         assertEquals(wrapped.right(), nmsEither.right());
     }
+
+	@Test
+	public void testPacketContainerConverter() {
+		for (PacketType type : PacketType.values()) {
+			if(!type.isSupported()) {
+				continue;
+			}
+			PacketContainer container = new PacketContainer(type);
+			Object generic = BukkitConverters.getPacketContainerConverter().getGeneric(container);
+			Object specific = BukkitConverters.getPacketContainerConverter().getSpecific(generic);
+			assertTrue(EqualsBuilder.reflectionEquals(container, specific)); // PacketContainer does not properly implement equals(.)
+		}
+	}
 }

--- a/src/test/java/com/comphenix/protocol/wrappers/ConverterTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/ConverterTest.java
@@ -1,0 +1,27 @@
+package com.comphenix.protocol.wrappers;
+
+import com.comphenix.protocol.reflect.EquivalentConverter;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Lukas Alt
+ * @since 26.03.2023
+ */
+public class ConverterTest {
+    @Test
+    public void testIterableConverter() {
+        EquivalentConverter<Iterable<String>> converter = Converters.iterable(Converters.passthrough(String.class), ArrayList::new, ArrayList::new);
+        List<String> l = Arrays.asList("a", "b", "c");
+        Object generic = converter.getGeneric(l);
+        Object specific = converter.getSpecific(generic);
+        assertEquals(l, specific);
+    }
+}


### PR DESCRIPTION
Since Minecraft 1.19.4, the protocol supports bundling consecutive packets to ensure the client processes them in one tick. However, Packet Events are not called for the individual packets in such a bundle in the current dev build of ProtocolLib.  For example, no packet events are currently sent for the ENTITY_METADATA packet when an entity is first spawned as the packet is bundled with the ENTITY_SPAWN packet. However, if the entity metadata is changed later on, the event will be called.
This PR proposes to fix this by unpacking the bundled packets and invoking the packet filtering for each packet.

I also want to briefly explain how the bundling works. A bundle starts with a PACKET_DELIMITER (0x00, `net.minecraft.network.protocol.BundleDelimiterPacket`) packet followed by all packets that should be bundled and finished with another PACKET_DELIMITER (0x00). Within the Netty pipeline, this sequence is transformed into one synthesized packet found in `net.minecraft.network.protocol.game.ClientboundBundlePacket`, which is essentially just a list of packets. At the stage at which ProtocolLib injects into the clientbound netty pipeline, this packet has not been unpacked yet. Thus, we need to handle the `ClientboundBundlePacket`, which unfortunately is not registered in ProtocolLib. The fact that two different classes map to the same packet currently requires a dirty remapping in the packet structure modifier.
Maybe someone can think of a better solution for this?

Fixes #2244 


