### PR TITLE
Fix /packet arguments, fixes #1847

### DIFF
--- a/src/main/java/com/comphenix/protocol/CommandPacket.java
+++ b/src/main/java/com/comphenix/protocol/CommandPacket.java
@@ -446,7 +446,7 @@ class CommandPacket extends CommandBase {
 	{
 		final String text = arguments.remove().toLowerCase();
 
-		switch (arguments.remove().toLowerCase()) {
+		switch (text) {
 			case "add":
 				return SubCommand.ADD;
 			case "remove":


### PR DESCRIPTION
Pretty simple, it's deleting the argument twice. Which means you have to use `/packet add add <remaining>`