### PR TITLE
Get around expensive validate calls

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/EntityUtilities.java
+++ b/src/main/java/com/comphenix/protocol/injector/EntityUtilities.java
@@ -178,7 +178,9 @@ class EntityUtilities {
 		Validate.notNull(entity, "entity cannot be null");
 
 		Object trackerEntry = this.getEntityTrackerEntry(entity.getWorld(), entity.getEntityId());
-		Validate.notNull(trackerEntry, "Could not find entity trackers for " + entity);
+		if (trackerEntry == null) { //entity.toString() is too expensive to be called every time
+			throw new IllegalArgumentException("Could not find entity trackers for " + entity);
+		}
 
 		if (this.trackedPlayersField == null) {
 			this.trackedPlayersField = Accessors.getFieldAccessor(


### PR DESCRIPTION
This validation call is very expensive to a user who uses a plugin of mine that hooks into ProtocolLib. The `toString()` call on entities should be unnecessarily expensive since it calls even when there are no errors.