### PR TITLE
Fixed null packet handles in Bundle

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/PacketEvent.java
+++ b/src/main/java/com/comphenix/protocol/events/PacketEvent.java
@@ -92,6 +92,9 @@ public class PacketEvent extends EventObject implements Cancellable {
 	private PacketEvent(Object source, PacketContainer packet, NetworkMarker marker, Player player, boolean serverPacket,
 			boolean filtered, @Nullable PacketEvent bundleEvent) {
 		super(source);
+		if(packet == null) {
+			throw new IllegalArgumentException("packet cannot be null");
+		}
 		this.packet = packet;
 		this.playerReference = new WeakReference<>(player);
 		this.networkMarker = marker;

--- a/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
@@ -620,7 +620,7 @@ public class BukkitConverters {
 	}
 
 	public static EquivalentConverter<PacketContainer> getPacketContainerConverter() {
-		return handle(PacketContainer::getHandle, PacketContainer::fromPacket, PacketContainer.class);
+		return ignoreNull(handle(PacketContainer::getHandle, PacketContainer::fromPacket, PacketContainer.class));
 	}
 
 	/**

--- a/src/main/java/com/comphenix/protocol/wrappers/Converters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/Converters.java
@@ -14,25 +14,21 @@
  */
 package com.comphenix.protocol.wrappers;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
 import com.comphenix.protocol.reflect.EquivalentConverter;
 import com.comphenix.protocol.reflect.FuzzyReflection;
 import com.comphenix.protocol.reflect.accessors.Accessors;
 import com.comphenix.protocol.reflect.accessors.MethodAccessor;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyMethodContract;
 import com.comphenix.protocol.utility.MinecraftReflection;
-import org.checkerframework.checker.units.qual.C;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Utility class for converters


### PR DESCRIPTION
For some reason, some users report null packet handles in packet bundles. This PR introduces changes to properly handle this and introduces additional logging to narrow down the actual cause of the problem.

Fixes #2277, #2308, #2322, #2293