### PR TITLE
Fix bundle packet processing errors

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
@@ -30,7 +30,6 @@ import com.comphenix.protocol.reflect.StructureModifier;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyFieldContract;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.utility.MinecraftVersion;
-import com.comphenix.protocol.utility.Util;
 
 /**
  * Static packet registry in Minecraft.
@@ -254,10 +253,6 @@ public class PacketRegistry {
 		for (Map.Entry<Integer, Class<?>> entry : lookup.entrySet()) {
 			int packetId = entry.getKey();
 			Class<?> packetClass = entry.getValue();
-
-			if (MinecraftReflection.isBundleDelimiter(packetClass)) {
-				continue;
-			}
 
 			PacketType type = PacketType.fromCurrent(protocol, sender, packetId, packetClass);
 


### PR DESCRIPTION
Reverts a change from the previous commit that broke ProtocolLib on 1.19.4 servers (easy to reproduce by starting a 1.19.4 server and joining, as long as some entities are around the client should be kicked with an error: https://paste.gg/p/anonymous/b3ea3e7bb1dd482ea738b5b3924049b5)

Not sure what the reason for adding the check was, otherwise you'd need to check for the bundle type deeper down the injector