### PR TITLE
Improved Wrapping of PlayerInfoData and support chat session data

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -961,7 +961,7 @@ public abstract class AbstractStructure {
     }
 
     /**
-     * Retrieve a read/write structure for profile public keys in 1.9
+     * Retrieve a read/write structure for profile public keys in 1.19
      * @return The Structure Modifier
      */
     public StructureModifier<WrappedProfilePublicKey> getProfilePublicKeys() {
@@ -971,13 +971,24 @@ public abstract class AbstractStructure {
     }
 
     /**
-     * Retrieve a read/write structure for profile public key data in 1.9
+     * Retrieve a read/write structure for profile public key data in 1.19
      * @return The Structure Modifier
      */
     public StructureModifier<WrappedProfileKeyData> getProfilePublicKeyData() {
         return structureModifier.withType(
-            MinecraftReflection.getProfilePublicKeyDataClass(),
-            BukkitConverters.getWrappedPublicKeyDataConverter());
+                MinecraftReflection.getProfilePublicKeyDataClass(),
+                BukkitConverters.getWrappedPublicKeyDataConverter());
+    }
+
+    /**
+     * Retrieves read/write structure for remote chat session data in 1.19.3
+     * @return The Structure Modifier
+     */
+    public StructureModifier<WrappedRemoteChatSessionData> getRemoteChatSessionData() {
+        return structureModifier.withType(
+                MinecraftReflection.getRemoteChatSessionDataClass(),
+                BukkitConverters.getWrappedRemoteChatSessionDataConverter()
+        );
     }
 
     /**

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -1621,6 +1621,10 @@ public final class MinecraftReflection {
 		return getMinecraftClass("network.chat.RemoteChatSession");
 	}
 
+	public static Class<?> getRemoteChatSessionDataClass() {
+		return getRemoteChatSessionClass().getClasses()[0];
+	}
+
 	public static Class<?> getFastUtilClass(String className) {
 		return getLibraryClass("it.unimi.dsi.fastutil." + className);
 	}

--- a/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
@@ -604,6 +604,10 @@ public class BukkitConverters {
 		return ignoreNull(handle(WrappedProfileKeyData::getHandle, WrappedProfileKeyData::new, WrappedProfileKeyData.class));
 	}
 
+	public static EquivalentConverter<WrappedRemoteChatSessionData> getWrappedRemoteChatSessionDataConverter() {
+		return ignoreNull(handle(WrappedRemoteChatSessionData::getHandle, WrappedRemoteChatSessionData::new, WrappedRemoteChatSessionData.class));
+	}
+
 	/**
 	 * @return converter for cryptographic signature data that are used in login and chat packets
 	 */

--- a/src/main/java/com/comphenix/protocol/wrappers/PlayerInfoData.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/PlayerInfoData.java
@@ -60,7 +60,23 @@ public class PlayerInfoData {
 	}
 
 	/**
-	 * Constructs a new PlayerInfoData for Minecraft 1.19.
+	 * Constructs a new PlayerInfoData for Minecraft 1.19 or later without signature data
+	 * @see PlayerInfoData#PlayerInfoData(UUID, int, boolean, NativeGameMode, WrappedGameProfile, WrappedChatComponent, WrappedRemoteChatSessionData)
+	 *
+	 * @param profileId the id of the profile (has to be non-null)
+	 * @param latency the latency in milliseconds
+	 * @param listed whether the player is listed in the tab list
+	 * @param gameMode the game mode
+	 * @param profile the game profile
+	 * @param displayName display name in tab list (optional)
+	 */
+	public PlayerInfoData(UUID profileId, int latency, boolean listed, NativeGameMode gameMode, WrappedGameProfile profile, WrappedChatComponent displayName) {
+		this(profileId, latency, listed, gameMode, profile, displayName, (WrappedRemoteChatSessionData) null);
+	}
+
+	/**
+	 * Constructs a new PlayerInfoData for Minecraft 1.19. This is incompatible on 1.19.3.
+	 * @see PlayerInfoData#PlayerInfoData(UUID, int, boolean, NativeGameMode, WrappedGameProfile, WrappedChatComponent, WrappedRemoteChatSessionData)
 	 *
 	 * @param profileId the id of the profile (has to be non-null)
 	 * @param latency the latency in milliseconds
@@ -71,7 +87,7 @@ public class PlayerInfoData {
 	 * @param profileKeyData the public key for the profile or null
 	 */
 	@Deprecated
-	public PlayerInfoData(UUID profileId, int latency, boolean listed, NativeGameMode gameMode, WrappedGameProfile profile, WrappedChatComponent displayName, WrappedProfileKeyData profileKeyData) {
+	public PlayerInfoData(UUID profileId, int latency, boolean listed, NativeGameMode gameMode, WrappedGameProfile profile, WrappedChatComponent displayName, @Nullable WrappedProfileKeyData profileKeyData) {
 		this.profileId = profileId;
 		this.latency = latency;
 		this.listed = listed;
@@ -93,7 +109,7 @@ public class PlayerInfoData {
 	 * @param displayName display name in tab list (optional)
 	 * @param remoteChatSession the remote chat session for this profile or null
 	 */
-	public PlayerInfoData(UUID profileId, int latency, boolean listed, NativeGameMode gameMode, WrappedGameProfile profile, WrappedChatComponent displayName, WrappedRemoteChatSessionData remoteChatSession) {
+	public PlayerInfoData(UUID profileId, int latency, boolean listed, NativeGameMode gameMode, WrappedGameProfile profile, WrappedChatComponent displayName, @Nullable WrappedRemoteChatSessionData remoteChatSession) {
 		this.profileId = profileId;
 		this.latency = latency;
 		this.listed = listed;

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedRemoteChatSessionData.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedRemoteChatSessionData.java
@@ -1,0 +1,96 @@
+package com.comphenix.protocol.wrappers;
+
+import com.comphenix.protocol.reflect.StructureModifier;
+import com.comphenix.protocol.reflect.accessors.Accessors;
+import com.comphenix.protocol.reflect.accessors.ConstructorAccessor;
+import com.comphenix.protocol.utility.MinecraftReflection;
+
+import java.util.UUID;
+
+/**
+ * A wrapper around the remote chat session.
+ *
+ * @since 1.19.3
+ */
+public class WrappedRemoteChatSessionData extends AbstractWrapper {
+	private final static Class<?> HANDLE_TYPE = MinecraftReflection.getRemoteChatSessionDataClass();
+	private static ConstructorAccessor CONSTRUCTOR;
+	private StructureModifier<Object> modifier;
+
+	/**
+	 * Constructs a new profile public key wrapper directly from a nms RemoteChatSession.Data/RemoteChatSession.a object.
+	 *
+	 * @param handle the handle to create the wrapper from.
+	 */
+	public WrappedRemoteChatSessionData(Object handle) {
+		super(HANDLE_TYPE);
+		this.setHandle(handle);
+	}
+
+	public WrappedRemoteChatSessionData(UUID sessionId, WrappedProfilePublicKey.WrappedProfileKeyData profilePublicKey) {
+		super(HANDLE_TYPE);
+		if (CONSTRUCTOR == null) {
+			CONSTRUCTOR = Accessors.getConstructorAccessor(
+					this.getHandleType(),
+					UUID.class, MinecraftReflection.getProfilePublicKeyDataClass());
+		}
+
+		this.setHandle(CONSTRUCTOR.invoke(sessionId, profilePublicKey.getHandle()));
+	}
+
+	/**
+	 * Retrieves the id of the current session
+	 * @return session id
+	 */
+	public UUID getSessionID() {
+		return this.modifier.<UUID>withType(UUID.class).read(0);
+	}
+
+	/**
+	 * Set the id for this session
+	 * @param sessionId new session id
+	 */
+	public void setSessionID(UUID sessionId) {
+		this.modifier.<UUID>withType(UUID.class).write(0, sessionId);
+	}
+
+	/**
+	 * Retrieves the ProfileKeyData
+	 * @return the public key data for this session
+	 */
+	public WrappedProfilePublicKey.WrappedProfileKeyData getProfilePublicKey() {
+		return this.modifier.withType(MinecraftReflection.getProfilePublicKeyDataClass(), BukkitConverters.getWrappedPublicKeyDataConverter()).read(0);
+	}
+
+	/**
+	 * Set the profile key data for this session
+	 * @param data ProfileKeyData
+	 */
+	public void setProfilePublicKey(WrappedProfilePublicKey.WrappedProfileKeyData data) {
+		this.modifier.withType(MinecraftReflection.getProfilePublicKeyDataClass(), BukkitConverters.getWrappedPublicKeyDataConverter()).write(0, data);
+	}
+
+	@Override
+	protected void setHandle(Object handle) {
+		super.setHandle(handle);
+		this.modifier = new StructureModifier<>(HANDLE_TYPE).withTarget(handle);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if(obj instanceof WrappedRemoteChatSessionData) {
+			return handle.equals(((WrappedRemoteChatSessionData) obj).getHandle());
+		}
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return handle.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		return handle.hashCode();
+	}
+}

--- a/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
+++ b/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
@@ -40,26 +40,13 @@ import com.comphenix.protocol.reflect.accessors.FieldAccessor;
 import com.comphenix.protocol.reflect.cloning.SerializableCloner;
 import com.comphenix.protocol.utility.MinecraftMethods;
 import com.comphenix.protocol.utility.MinecraftReflection;
-import com.comphenix.protocol.wrappers.BlockPosition;
-import com.comphenix.protocol.wrappers.BukkitConverters;
-import com.comphenix.protocol.wrappers.ComponentConverter;
-import com.comphenix.protocol.wrappers.EnumWrappers;
+import com.comphenix.protocol.wrappers.*;
 import com.comphenix.protocol.wrappers.EnumWrappers.Direction;
 import com.comphenix.protocol.wrappers.EnumWrappers.EntityUseAction;
 import com.comphenix.protocol.wrappers.EnumWrappers.Hand;
 import com.comphenix.protocol.wrappers.EnumWrappers.NativeGameMode;
 import com.comphenix.protocol.wrappers.EnumWrappers.SoundCategory;
-import com.comphenix.protocol.wrappers.MovingObjectPositionBlock;
-import com.comphenix.protocol.wrappers.Pair;
-import com.comphenix.protocol.wrappers.PlayerInfoData;
-import com.comphenix.protocol.wrappers.WrappedBlockData;
-import com.comphenix.protocol.wrappers.WrappedChatComponent;
-import com.comphenix.protocol.wrappers.WrappedDataValue;
-import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher.Registry;
-import com.comphenix.protocol.wrappers.WrappedEnumEntityUseAction;
-import com.comphenix.protocol.wrappers.WrappedGameProfile;
-import com.comphenix.protocol.wrappers.WrappedRegistry;
 import com.comphenix.protocol.wrappers.nbt.NbtCompound;
 import com.comphenix.protocol.wrappers.nbt.NbtFactory;
 import com.google.common.collect.Lists;
@@ -768,7 +755,7 @@ public class PacketContainerTest {
 				NativeGameMode.CREATIVE,
 				new WrappedGameProfile(new UUID(0, 0), "system"),
 				null,
-				null);
+				(WrappedRemoteChatSessionData) null);
 		updatePlayerInfoActions.getPlayerInfoDataLists().write(1, Collections.singletonList(data));
 
 		Set<EnumWrappers.PlayerInfoAction> readActions = updatePlayerInfoActions.getPlayerInfoActions().read(0);
@@ -871,7 +858,6 @@ public class PacketContainerTest {
 				}
 
 				// gives some indication which cloning process fails as the checks itself are happening outside this method
-				System.out.println("Cloning " + type);
 
 				// Clone the packet all three ways
 				PacketContainer shallowCloned = constructed.shallowClone();
@@ -886,8 +872,8 @@ public class PacketContainerTest {
 					serializedCloned.getLongs().write(0, 0L);
 				}
 				this.assertPacketsEqualAndSerializable(constructed, serializedCloned);
-			} catch (Exception ex) {
-				Assertions.fail("Unable to clone " + type, ex);
+			} catch (Throwable t) {
+				Assertions.fail("Unable to clone " + type, t);
 			}
 		}
 	}

--- a/src/test/java/com/comphenix/protocol/utility/TestUtils.java
+++ b/src/test/java/com/comphenix/protocol/utility/TestUtils.java
@@ -7,7 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.comphenix.protocol.reflect.accessors.Accessors;
 import java.lang.reflect.Field;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.time.Instant;
 import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import com.comphenix.protocol.wrappers.WrappedProfilePublicKey;
+import com.comphenix.protocol.wrappers.WrappedRemoteChatSessionData;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 
@@ -48,5 +56,18 @@ public class TestUtils {
 
 	public static void setFinalField(Object obj, Field field, Object newValue) {
 		Accessors.getFieldAccessor(field).set(obj, newValue);
+	}
+
+	public static KeyPair generateKeyPair() throws Exception {
+		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+		keyPairGenerator.initialize(1024);
+		return keyPairGenerator.generateKeyPair();
+	}
+
+	public static WrappedRemoteChatSessionData creteDummyRemoteChatSessionData() throws Exception {
+		byte[] signature = new byte[256];
+		new Random().nextBytes(signature);
+
+		return new WrappedRemoteChatSessionData(UUID.randomUUID(), new WrappedProfilePublicKey.WrappedProfileKeyData(Instant.now(), TestUtils.generateKeyPair().getPublic(), signature));
 	}
 }

--- a/src/test/java/com/comphenix/protocol/wrappers/BukkitConvertersTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/BukkitConvertersTest.java
@@ -1,15 +1,11 @@
 package com.comphenix.protocol.wrappers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.comphenix.protocol.BukkitInitialization;
 import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.reflect.EquivalentConverter;
+import com.comphenix.protocol.utility.TestUtils;
 import com.comphenix.protocol.wrappers.Either.Left;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -20,37 +16,50 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.Instant;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class BukkitConvertersTest {
 
-	@BeforeAll
-	public static void beforeClass() {
-		BukkitInitialization.initializeAll();
-	}
+    @BeforeAll
+    public static void beforeClass() {
+        BukkitInitialization.initializeAll();
+    }
 
-	@Test
-	public void testItemStacks() {
-		ItemStack item = new ItemStack(Material.DIAMOND_SWORD, 16);
-		item.addEnchantment(Enchantment.DAMAGE_ALL, 4);
-		ItemMeta meta = item.getItemMeta();
-		meta.setDisplayName(ChatColor.GREEN + "Diamond Sword");
-		item.setItemMeta(meta);
+    @Test
+    public void testItemStacks() {
+        ItemStack item = new ItemStack(Material.DIAMOND_SWORD, 16);
+        item.addEnchantment(Enchantment.DAMAGE_ALL, 4);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(ChatColor.GREEN + "Diamond Sword");
+        item.setItemMeta(meta);
 
-		EquivalentConverter<ItemStack> converter = BukkitConverters.getItemStackConverter();
-		Object nmsStack = converter.getGeneric(item);
-		ItemStack back = converter.getSpecific(nmsStack);
+        EquivalentConverter<ItemStack> converter = BukkitConverters.getItemStackConverter();
+        Object nmsStack = converter.getGeneric(item);
+        ItemStack back = converter.getSpecific(nmsStack);
 
-		assertEquals(item.getType(), back.getType());
-		assertEquals(item.getDurability(), back.getDurability());
-		assertEquals(item.hasItemMeta(), back.hasItemMeta());
-		assertTrue(Bukkit.getItemFactory().equals(item.getItemMeta(), back.getItemMeta()));
-	}
+        assertEquals(item.getType(), back.getType());
+        assertEquals(item.getDurability(), back.getDurability());
+        assertEquals(item.hasItemMeta(), back.hasItemMeta());
+        assertTrue(Bukkit.getItemFactory().equals(item.getItemMeta(), back.getItemMeta()));
+    }
 
     @Test
     public void testEither() {
         Either<String, String> test = new Left<>("bla");
 
         EquivalentConverter<Either<String, String>> converter = BukkitConverters.getEitherConverter(
-            Converters.passthrough(String.class), Converters.passthrough(String.class)
+                Converters.passthrough(String.class), Converters.passthrough(String.class)
         );
 
         com.mojang.datafixers.util.Either<String, String> nmsEither = (com.mojang.datafixers.util.Either<String, String>) converter.getGeneric(test);
@@ -60,16 +69,26 @@ public class BukkitConvertersTest {
         assertEquals(wrapped.right(), nmsEither.right());
     }
 
-	@Test
-	public void testPacketContainerConverter() {
-		for (PacketType type : PacketType.values()) {
-			if(!type.isSupported()) {
-				continue;
-			}
-			PacketContainer container = new PacketContainer(type);
-			Object generic = BukkitConverters.getPacketContainerConverter().getGeneric(container);
-			Object specific = BukkitConverters.getPacketContainerConverter().getSpecific(generic);
-			assertTrue(EqualsBuilder.reflectionEquals(container, specific)); // PacketContainer does not properly implement equals(.)
-		}
-	}
+    @Test
+    public void testPacketContainerConverter() {
+        for (PacketType type : PacketType.values()) {
+            if (!type.isSupported()) {
+                continue;
+            }
+            PacketContainer container = new PacketContainer(type);
+            Object generic = BukkitConverters.getPacketContainerConverter().getGeneric(container);
+            Object specific = BukkitConverters.getPacketContainerConverter().getSpecific(generic);
+            assertTrue(EqualsBuilder.reflectionEquals(container, specific)); // PacketContainer does not properly implement equals(.)
+        }
+    }
+
+    @Test
+    public void testRemoteChatSessionDataConverter() throws Exception {
+        WrappedRemoteChatSessionData wrappedRemoteChatSessionData = TestUtils.creteDummyRemoteChatSessionData();
+        Object generic = BukkitConverters.getWrappedRemoteChatSessionDataConverter().getGeneric(wrappedRemoteChatSessionData);
+
+		WrappedRemoteChatSessionData specific = BukkitConverters.getWrappedRemoteChatSessionDataConverter().getSpecific(generic);
+		assertEquals(wrappedRemoteChatSessionData, specific);
+
+    }
 }

--- a/src/test/java/com/comphenix/protocol/wrappers/PlayerInfoDataTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/PlayerInfoDataTest.java
@@ -41,7 +41,7 @@ public class PlayerInfoDataTest {
 		testWriteBack(new PlayerInfoData(profile, 42, NativeGameMode.CREATIVE, displayName));
 		testWriteBack(new PlayerInfoData(profile.getUUID(), 42, false, NativeGameMode.CREATIVE, profile, displayName, TestUtils.creteDummyRemoteChatSessionData()));
 		testWriteBack(new PlayerInfoData(profile.getUUID(), 42, false, NativeGameMode.CREATIVE, null, null, TestUtils.creteDummyRemoteChatSessionData()));
-		testWriteBack(new PlayerInfoData(profile.getUUID(), 42, false, NativeGameMode.CREATIVE, null, displayName, (WrappedRemoteChatSessionData) null));
+		testWriteBack(new PlayerInfoData(profile.getUUID(), 42, true, NativeGameMode.CREATIVE, null, displayName));
 	}
 
 	private static void testWriteBack(PlayerInfoData data) {

--- a/src/test/java/com/comphenix/protocol/wrappers/PlayerInfoDataTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/PlayerInfoDataTest.java
@@ -17,6 +17,7 @@ package com.comphenix.protocol.wrappers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.comphenix.protocol.BukkitInitialization;
+import com.comphenix.protocol.utility.TestUtils;
 import com.comphenix.protocol.wrappers.EnumWrappers.NativeGameMode;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
@@ -33,14 +34,19 @@ public class PlayerInfoDataTest {
 	}
 
 	@Test
-	public void test() {
+	public void test() throws Exception {
 		WrappedGameProfile profile = new WrappedGameProfile(UUID.randomUUID(), "Name");
 		WrappedChatComponent displayName = WrappedChatComponent.fromText("Name's Name");
 
-		PlayerInfoData data = new PlayerInfoData(profile, 42, NativeGameMode.CREATIVE, displayName);
+		testWriteBack(new PlayerInfoData(profile, 42, NativeGameMode.CREATIVE, displayName));
+		testWriteBack(new PlayerInfoData(profile.getUUID(), 42, false, NativeGameMode.CREATIVE, profile, displayName, TestUtils.creteDummyRemoteChatSessionData()));
+		testWriteBack(new PlayerInfoData(profile.getUUID(), 42, false, NativeGameMode.CREATIVE, null, null, TestUtils.creteDummyRemoteChatSessionData()));
+		testWriteBack(new PlayerInfoData(profile.getUUID(), 42, false, NativeGameMode.CREATIVE, null, displayName, (WrappedRemoteChatSessionData) null));
+	}
+
+	private static void testWriteBack(PlayerInfoData data) {
 		Object generic = PlayerInfoData.getConverter().getGeneric(data);
 		PlayerInfoData back = PlayerInfoData.getConverter().getSpecific(generic);
-
 		assertEquals(data, back);
 	}
 }


### PR DESCRIPTION
In 1.19.3, the ProfilePublicKey field in the PlayerInfoData has been replaced with a RemoteSessionData, which is essentially just a composite of the session id and the previous public key data. However, this has not been properly implemented so far leading to potential disconnects due to invalid/missing signatures like #2352. 

This PR aims to implement this while maintaining compatibility with 1.19-1.19.2. Also, I fixed a few minor edge cases.