### PR TITLE
Fixed creation of packet bundles

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
@@ -363,6 +363,9 @@ public class PacketRegistry {
 		// Try the lookup first (may be null, so check contains)
 		Optional<Class<?>> res = REGISTER.typeToClass.get(type);
 		if (res != null) {
+			if(res.isPresent() && MinecraftReflection.isBundleDelimiter(res.get())) {
+				return MinecraftReflection.getPackedBundlePacketClass();
+			}
 			return res;
 		}
 
@@ -375,6 +378,9 @@ public class PacketRegistry {
 
 		// cache it for next time
 		associate(type, clazz);
+		if(clazz != null && MinecraftReflection.isBundleDelimiter(clazz)) {
+			clazz = MinecraftReflection.getPackedBundlePacketClass().orElseThrow(() -> new IllegalStateException("Packet bundle class not found."));
+		}
 		return Optional.ofNullable(clazz);
 	}
 

--- a/src/test/java/com/comphenix/protocol/PacketTypeTest.java
+++ b/src/test/java/com/comphenix/protocol/PacketTypeTest.java
@@ -22,6 +22,7 @@ import com.comphenix.protocol.PacketType.Protocol;
 import com.comphenix.protocol.PacketType.Sender;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.injector.packet.PacketRegistry;
+import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.utility.MinecraftReflectionTestUtil;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -31,6 +32,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+
+import com.comphenix.protocol.wrappers.BukkitConverters;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import net.minecraft.network.EnumProtocol;
 import net.minecraft.network.protocol.EnumProtocolDirection;
 import net.minecraft.network.protocol.login.PacketLoginInStart;
@@ -356,5 +360,18 @@ public class PacketTypeTest {
 			}
 		}
 		assertFalse(fail, "Packet type(s) failed to instantiate");
+	}
+
+	@Test
+	public void testPacketBundleWriting() {
+		PacketContainer bundlePacket = new PacketContainer(PacketType.Play.Server.BUNDLE);
+		assertEquals(MinecraftReflection.getPackedBundlePacketClass().orElseThrow(() -> new IllegalStateException("Packet Bundle class is not present")), bundlePacket.getHandle().getClass());
+		List<PacketContainer> bundle = new ArrayList<>();
+
+		PacketContainer chatMessage = new PacketContainer(PacketType.Play.Server.SYSTEM_CHAT);
+		chatMessage.getStrings().write(0, WrappedChatComponent.fromText("Test").getJson());
+		chatMessage.getBooleans().write(0, false);
+		bundle.add(chatMessage);
+		bundlePacket.getPacketBundles().write(0, bundle);
 	}
 }


### PR DESCRIPTION
If a new PacketContainer of type `PacketType.Play.Server.BUNDLE` is created manually, the underlying handle will be of type `BundleDelimiter` and not the synthetic packet `Bundle`

Fixes #2363