### PR TITLE
[WIP] Add missing wrappers for new field types in 1.19+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,24 +205,6 @@
 							</execution>
 						</executions>
 					</plugin>
-
-					<!-- TODO: Look into signing releases
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					-->
-
 				</plugins>
 			</build>
 		</profile>

--- a/src/main/java/com/comphenix/protocol/CommandFilter.java
+++ b/src/main/java/com/comphenix/protocol/CommandFilter.java
@@ -40,7 +40,7 @@ public class CommandFilter extends CommandBase {
 	public static final ReportType REPORT_FILTER_REMOVED_FOR_ERROR = new ReportType("Removing filter %s for causing %s.");
 	public static final ReportType REPORT_CANNOT_HANDLE_CONVERSATION = new ReportType("Cannot handle conversation.");
 	
-	public interface FilterFailedHandler{
+	public interface FilterFailedHandler {
 		/**
 		 * Invoked when a given filter has failed.
 		 * @param event - the packet event.

--- a/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
@@ -39,9 +39,9 @@ public class ProtocolLibrary {
 	public static final String MAXIMUM_MINECRAFT_VERSION = MinecraftVersion.LATEST.getVersion();
 
 	/**
-	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.19.2) was released.
+	 * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.19.4) was released.
 	 */
-	public static final String MINECRAFT_LAST_RELEASE_DATE = "2022-08-05";
+	public static final String MINECRAFT_LAST_RELEASE_DATE = "2022-03-14";
 
 	/**
 	 * Plugins that are currently incompatible with ProtocolLib.

--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -629,6 +629,7 @@ public abstract class AbstractStructure {
      * Retrieve a read/write structure for the PlayerInfo enum in 1.8.
      * @return A modifier for PlayerInfoAction enum fields.
      */
+    @Deprecated
     public StructureModifier<EnumWrappers.PlayerInfoAction> getPlayerInfoAction() {
         // Convert to and from the wrapper
         return structureModifier.withType(
@@ -991,6 +992,15 @@ public abstract class AbstractStructure {
         );
     }
 
+
+    public StructureModifier<EnumWrappers.AdvancementAction> getAdvancementActions() {
+        return structureModifier.withType(EnumWrappers.getAdvancementActionClass(), EnumWrappers.getAdvancementActionConverter());
+    }
+
+    public StructureModifier<EnumWrappers.RecipeBookType> getRecipeBookTypes() {
+        return structureModifier.withType(EnumWrappers.getRecipeBookTypeClass(), EnumWrappers.getRecipeBookTypeConverter());
+    }
+
     /**
      * Retrieve a read/write structure for LevelChunkPacketData in 1.18+
      *
@@ -1142,10 +1152,23 @@ public abstract class AbstractStructure {
         return structureModifier.withType(Optional.class, Converters.optional(converter));
     }
 
+    /**
+     * Retrieve a read/write structure for a iterable
+     * of packets
+     * @return The modifier
+     */
     public StructureModifier<Iterable<PacketContainer>> getPacketBundles() {
         return structureModifier.withType(Iterable.class, Converters.iterable(
             BukkitConverters.getPacketContainerConverter(), ArrayList::new, ArrayList::new
         ));
+    }
+
+    /**
+     * Retrieves a read/write structure for a WrappedPacketDataSerializer
+     * @return The modifier
+     */
+    public StructureModifier<WrappedPacketDataSerializer> getPacketDataSerializers() {
+        return structureModifier.withType(WrappedPacketDataSerializer.PACKET_DATA_SERIALIZER_CLASS, WrappedPacketDataSerializer.getConverter());
     }
 
     /**

--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -413,12 +413,23 @@ public abstract class AbstractStructure {
      * <p>
      * This modifier will automatically marshal between Material and the
      * internal Minecraft Block.
-     * @return A modifier for GameProfile fields.
+     * @return A modifier for Block fields.
      */
     public StructureModifier<Material> getBlocks() {
         // Convert to and from the Bukkit wrapper
         return structureModifier.withType(
                 MinecraftReflection.getBlockClass(), BukkitConverters.getBlockConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for Items/Materials
+     * <p>
+     * This modifier will automatically marshal between Material and the
+     * internal Minecraft Item.
+     * @return A modifier for Item fields.
+     */
+    public StructureModifier<Material> getMaterials() {
+        return structureModifier.withType(MinecraftReflection.getItemClass(), BukkitConverters.getMaterialConverter());
     }
 
     /**
@@ -992,15 +1003,6 @@ public abstract class AbstractStructure {
         );
     }
 
-
-    public StructureModifier<EnumWrappers.AdvancementAction> getAdvancementActions() {
-        return structureModifier.withType(EnumWrappers.getAdvancementActionClass(), EnumWrappers.getAdvancementActionConverter());
-    }
-
-    public StructureModifier<EnumWrappers.RecipeBookType> getRecipeBookTypes() {
-        return structureModifier.withType(EnumWrappers.getRecipeBookTypeClass(), EnumWrappers.getRecipeBookTypeConverter());
-    }
-
     /**
      * Retrieve a read/write structure for LevelChunkPacketData in 1.18+
      *
@@ -1044,6 +1046,86 @@ public abstract class AbstractStructure {
                 MinecraftReflection.getMessageSignatureClass(),
                 BukkitConverters.getWrappedMessageSignatureConverter()
         );
+    }
+
+    /**
+     * Retrieves a read/write structure for
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.AdvancementAction> getAdvancementActions() {
+        return structureModifier.withType(EnumWrappers.getAdvancementActionClass(), EnumWrappers.getAdvancementActionConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for RecipeBookType
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.RecipeBookType> getRecipeBookTypes() {
+        return structureModifier.withType(EnumWrappers.getRecipeBookTypeClass(), EnumWrappers.getRecipeBookTypeConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for HumanoidArm
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.HumanoidArm> getHumanoidArms() {
+        return structureModifier.withType(EnumWrappers.getHumanoidArmClass(), EnumWrappers.getHumanoidArmConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for CommandBlockMode
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.CommandBlockMode> getCommandBlockModes() {
+        return structureModifier.withType(EnumWrappers.getCommandBlockModeClass(), EnumWrappers.getCommandBlockModeConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for JointType
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.JointType> getJointTypes() {
+        return structureModifier.withType(EnumWrappers.getJointTypeClass(), EnumWrappers.getJointTypeConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for StructureBlockUpdateType
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.StructureBlockUpdateType> getStructureBlockUpdateTypes() {
+        return structureModifier.withType(EnumWrappers.getStructureBlockUpdateTypeClass(), EnumWrappers.getStructureBlockUpdateTypeConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for StructureMode
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.StructureMode> getStructureModes() {
+        return structureModifier.withType(EnumWrappers.getStructureModeClass(), EnumWrappers.getStructureModeConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for CustomChatCompletionAction
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.CustomChatTabCompletionsAction> getCustomChatCompletionActions() {
+        return structureModifier.withType(EnumWrappers.getCustomChatCompletionActionClass(), EnumWrappers.getCustomChatCompletionActionConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for RecipeUpdateState
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.RecipeUpdateState> getRecipeUpdateStates() {
+        return structureModifier.withType(EnumWrappers.getRecipeUpdateStateClass(), EnumWrappers.getRecipeUpdateStateConverter());
+    }
+
+    /**
+     * Retrieves a read/write structure for ObjectiveRenderType
+     * @return The modifier
+     */
+    public StructureModifier<EnumWrappers.ObjectiveRenderType> getObjectiveRenderTypes() {
+        return structureModifier.withType(EnumWrappers.getObjectiveRenderTypeClass(), EnumWrappers.getObjectiveRenderTypeConverter());
     }
 
     /**

--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -354,6 +354,17 @@ public abstract class AbstractStructure {
     }
 
     /**
+     * Retrieves a read/write structure for Vector3I.
+     * @return A modifier for Vector3I
+     */
+    public StructureModifier<Vector3I> getVector3Is() {
+        // Automatically marshal between Vec3i and the Bukkit wrapper
+        return structureModifier.withType(
+                Vector3I.HANDLE_TYPE,
+                Vector3I.getConverter());
+    }
+
+    /**
      * Retrieves a read/write structure for collections of attribute snapshots.
      * <p>
      * This modifier will automatically marshal between the visible ProtocolLib WrappedAttribute and the

--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -1049,6 +1049,14 @@ public abstract class AbstractStructure {
     }
 
     /**
+     * Retrieves a read/write structure for access to FilterMask
+     * @return The modifier
+     */
+    public StructureModifier<WrappedFilterMask> getFilterMasks() {
+        return structureModifier.withType(WrappedFilterMask.HANDLE_CLASS, WrappedFilterMask.getConverter());
+    }
+
+    /**
      * Retrieves a read/write structure for
      * @return The modifier
      */

--- a/src/main/java/com/comphenix/protocol/reflect/accessors/Accessors.java
+++ b/src/main/java/com/comphenix/protocol/reflect/accessors/Accessors.java
@@ -15,7 +15,7 @@ public final class Accessors {
 	}
 
 	/**
-	 * Retrieve an accessor (in declared order) for every field of the givne type.
+	 * Retrieve an accessor (in declared order) for every field of the given type.
 	 *
 	 * @param clazz       - the type of the instance to retrieve.
 	 * @param fieldClass  - type of the field(s) to retrieve.

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -1386,7 +1386,7 @@ public final class MinecraftReflection {
 	 * @param aliases Potential aliases
 	 * @return Optional that may contain the class
 	 */
-	private static Optional<Class<?>> getOptionalNMS(String className, String... aliases) {
+	public static Optional<Class<?>> getOptionalNMS(String className, String... aliases) {
 		if (minecraftPackage == null) {
 			minecraftPackage = new CachedPackage(getMinecraftPackage(), getClassSource());
 		}

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -1047,6 +1047,15 @@ public final class MinecraftReflection {
 	}
 
 	/**
+	 * Retrieve the CraftMagicNumbers class.
+	 *
+	 * @return The CraftMagicNumbers class.
+	 */
+	public static Class<?> getCraftMagicNumbersClass() {
+		return getCraftBukkitClass("util.CraftMagicNumbers");
+	}
+
+	/**
 	 * Retrieve the CraftPlayer class.
 	 *
 	 * @return CraftPlayer class.

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftVersion.java
@@ -170,7 +170,7 @@ public final class MinecraftVersion implements Comparable<MinecraftVersion>, Ser
 	}
 
 	/**
-	 * Construct a version format from the standard release version or the snapshot verison.
+	 * Construct a version format from the standard release version or the snapshot version.
 	 *
 	 * @param versionOnly   - the version.
 	 * @param parseSnapshot - TRUE to parse the snapshot, FALSE otherwise.

--- a/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/BukkitConverters.java
@@ -933,7 +933,7 @@ public class BukkitConverters {
 	 */
 	public static EquivalentConverter<Material> getBlockConverter() {
 		if (BLOCK_FROM_MATERIAL == null || MATERIAL_FROM_BLOCK == null) {
-			Class<?> magicNumbers = MinecraftReflection.getCraftBukkitClass("util.CraftMagicNumbers");
+			Class<?> magicNumbers = MinecraftReflection.getCraftMagicNumbersClass();
 			Class<?> block = MinecraftReflection.getBlockClass();
 
 			FuzzyReflection fuzzy = FuzzyReflection.fromClass(magicNumbers);
@@ -1796,5 +1796,38 @@ public class BukkitConverters {
 				return Integer.class;
 			}
 		};
+	}
+
+	private static Class<?> CRAFT_MAGIC_NUMBERS_CLASS;
+	private static MethodAccessor ITEM_TO_MATERIAL_ACCESSOR;
+	private static MethodAccessor MATERIAL_TO_ITEM_ACCESSOR;
+
+	public static EquivalentConverter<Material> getMaterialConverter() {
+		if(CRAFT_MAGIC_NUMBERS_CLASS == null) {
+			CRAFT_MAGIC_NUMBERS_CLASS = MinecraftReflection.getCraftMagicNumbersClass();
+		}
+		if(ITEM_TO_MATERIAL_ACCESSOR == null) {
+			ITEM_TO_MATERIAL_ACCESSOR = Accessors.getMethodAccessor(CRAFT_MAGIC_NUMBERS_CLASS, "getMaterial", MinecraftReflection.getItemClass());
+		}
+		if(MATERIAL_TO_ITEM_ACCESSOR == null) {
+			MATERIAL_TO_ITEM_ACCESSOR = Accessors.getMethodAccessor(CRAFT_MAGIC_NUMBERS_CLASS, "getItem", Material.class);
+		}
+		return new EquivalentConverter<Material>() {
+			@Override
+			public Object getGeneric(Material specific) {
+				return MATERIAL_TO_ITEM_ACCESSOR.invoke(null, specific);
+			}
+
+			@Override
+			public Material getSpecific(Object generic) {
+				return (Material) ITEM_TO_MATERIAL_ACCESSOR.invoke(null, generic);
+			}
+
+			@Override
+			public Class<Material> getSpecificType() {
+				return Material.class;
+			}
+		};
+
 	}
 }

--- a/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
@@ -14,6 +14,7 @@ import com.comphenix.protocol.reflect.accessors.Accessors;
 import com.comphenix.protocol.utility.MinecraftVersion;
 import com.comphenix.protocol.utility.MinecraftReflection;
 
+import net.minecraft.util.OptionEnum;
 import org.apache.commons.lang.Validate;
 import org.bukkit.GameMode;
 
@@ -423,6 +424,65 @@ public abstract class EnumWrappers {
 		}
 	}
 
+	public enum AdvancementAction {
+		OPENED_TAB,
+		CLOSED_SCREEN
+	}
+
+	public enum RecipeBookType {
+		CRAFTING,
+		FURNACE,
+		BLAST_FURNACE,
+		SMOKER
+	}
+
+	public enum HumanoidArm {
+		LEFT,
+		RIGHT
+	}
+
+	public enum JointType {
+		ROLLABLE,
+		ALIGNED
+	}
+
+	public enum CommandBlockMode {
+		SEQUENCE,
+		AUTO,
+		REDSTONE
+	}
+
+	public enum StructureBlockUpdateType {
+		UPDATE_DATA,
+		SAVE_AREA,
+		LOAD_AREA,
+		SCAN_AREA;
+	}
+
+	public enum StructureMode {
+		SAVE,
+		LOAD,
+		CORNER,
+		DATA
+	}
+
+	public enum CustomChatTabCompletionsAction {
+		ADD,
+		REMOVE,
+		SET;
+	}
+
+	public enum RecipeUpdateState {
+		INIT,
+		ADD,
+		REMOVE;
+	}
+
+	public enum ObjectiveRenderType {
+		INTEGER,
+		HEARTS
+	}
+
 	public enum Dimension {
 		OVERWORLD(0),
 		THE_NETHER(-1),
@@ -469,6 +529,8 @@ public abstract class EnumWrappers {
 	private static Class<?> DIRECTION_CLASS = null;
 	private static Class<?> CHAT_TYPE_CLASS = null;
 	private static Class<?> ENTITY_POSE_CLASS = null;
+	private static Class<?> ADVANCEMENT_ACTION_CLASS = null;
+	private static Class<?> RECIPE_BOOK_TYPE_CLASS = null;
 
 	private static boolean INITIALIZED = false;
 	private static Map<Class<?>, EquivalentConverter<?>> FROM_NATIVE = new HashMap<>();
@@ -544,6 +606,8 @@ public abstract class EnumWrappers {
 
 		CHAT_TYPE_CLASS = getEnum(PacketType.Play.Server.CHAT.getPacketClass(), 0);
 		ENTITY_POSE_CLASS = MinecraftReflection.getNullableNMS("world.entity.EntityPose", "world.entity.Pose", "EntityPose");
+		ADVANCEMENT_ACTION_CLASS = MinecraftReflection.getNullableNMS("network.protocol.game.ServerboundSeenAdvancementsPacket.Action");
+		RECIPE_BOOK_TYPE_CLASS = MinecraftReflection.getNullableNMS("world.inventory.RecipeBookType");
 
 		associate(PROTOCOL_CLASS, Protocol.class, getProtocolConverter());
 		associate(CLIENT_COMMAND_CLASS, ClientCommand.class, getClientCommandConverter());
@@ -568,6 +632,12 @@ public abstract class EnumWrappers {
 
 		if (ENTITY_POSE_CLASS != null) {
 			associate(ENTITY_POSE_CLASS, EntityPose.class, getEntityPoseConverter());
+		}
+		if (ADVANCEMENT_ACTION_CLASS != null) {
+			associate(ADVANCEMENT_ACTION_CLASS, AdvancementAction.class, getAdvancementActionConverter());
+		}
+		if (RECIPE_BOOK_TYPE_CLASS != null) {
+			associate(RECIPE_BOOK_TYPE_CLASS, RecipeBookType.class, getRecipeBookTypeConverter());
 		}
 	}
 
@@ -716,6 +786,16 @@ public abstract class EnumWrappers {
 		return ENTITY_POSE_CLASS;
 	}
 
+	public static Class<?> getAdvancementActionClass() {
+		initialize();
+		return ADVANCEMENT_ACTION_CLASS;
+	}
+
+	public static Class<?> getRecipeBookTypeClass() {
+		initialize();
+		return RECIPE_BOOK_TYPE_CLASS;
+	}
+
 	// Get the converters
 	public static EquivalentConverter<Protocol> getProtocolConverter() {
 		return new EnumConverter<>(getProtocolClass(), Protocol.class);
@@ -804,6 +884,22 @@ public abstract class EnumWrappers {
 	public static EquivalentConverter<EntityPose> getEntityPoseConverter() {
 		if (getEntityPoseClass() == null) return null;
 		return new EnumConverter<>(getEntityPoseClass(), EntityPose.class);
+	}
+
+	/**
+	 * @since 1.19+
+	 */
+	public static EquivalentConverter<AdvancementAction> getAdvancementActionConverter() {
+		if(getAdvancementActionClass() == null) throw new IllegalStateException("AdvancementAction is only available since 1.19");
+		return new EnumConverter<>(getAdvancementActionClass(), AdvancementAction.class);
+	}
+
+	/**
+	 * @since 1.19+
+	 */
+	public static EquivalentConverter<RecipeBookType> getRecipeBookTypeConverter() {
+		if(getRecipeBookTypeClass() == null) throw new IllegalStateException("RecipeBookType is only available since 1.19");
+		return new EnumConverter<>(getRecipeBookTypeClass(), RecipeBookType.class);
 	}
 
 	/**

--- a/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/EnumWrappers.java
@@ -531,6 +531,14 @@ public abstract class EnumWrappers {
 	private static Class<?> ENTITY_POSE_CLASS = null;
 	private static Class<?> ADVANCEMENT_ACTION_CLASS = null;
 	private static Class<?> RECIPE_BOOK_TYPE_CLASS = null;
+	private static Class<?> HUMANOID_ARM_CLASS = null;
+	private static Class<?> JOINT_TYPE_CLASS = null;
+	private static Class<?> COMMAND_BLOCK_MODE_CLASS = null;
+	private static Class<?> STRUCTURE_BLOCK_UPDATE_TYPE_CLASS = null;
+	private static Class<?> STRUCTURE_MODE_CLASS = null;
+	private static Class<?> CUSTOM_CHAT_COMPLETION_ACTION_CLASS = null;
+	private static Class<?> RECIPE_UPDATE_STATE_CLASS = null;
+	private static Class<?> OBJECTIVE_RENDER_TYPE_CLASS = null;
 
 	private static boolean INITIALIZED = false;
 	private static Map<Class<?>, EquivalentConverter<?>> FROM_NATIVE = new HashMap<>();
@@ -605,9 +613,17 @@ public abstract class EnumWrappers {
 		}
 
 		CHAT_TYPE_CLASS = getEnum(PacketType.Play.Server.CHAT.getPacketClass(), 0);
-		ENTITY_POSE_CLASS = MinecraftReflection.getNullableNMS("world.entity.EntityPose", "world.entity.Pose", "EntityPose");
-		ADVANCEMENT_ACTION_CLASS = MinecraftReflection.getNullableNMS("network.protocol.game.ServerboundSeenAdvancementsPacket.Action");
-		RECIPE_BOOK_TYPE_CLASS = MinecraftReflection.getNullableNMS("world.inventory.RecipeBookType");
+		ENTITY_POSE_CLASS = MinecraftReflection.getOptionalNMS("world.entity.EntityPose", "world.entity.Pose", "EntityPose").orElse(null);
+		ADVANCEMENT_ACTION_CLASS = MinecraftReflection.getOptionalNMS("network.protocol.game.ServerboundSeenAdvancementsPacket.Action").orElse(null);
+		RECIPE_BOOK_TYPE_CLASS = MinecraftReflection.getOptionalNMS("world.inventory.RecipeBookType").orElse(null);
+		HUMANOID_ARM_CLASS = MinecraftReflection.getOptionalNMS("").orElse(null);
+		JOINT_TYPE_CLASS = MinecraftReflection.getOptionalNMS("").orElse(null);
+		COMMAND_BLOCK_MODE_CLASS = MinecraftReflection.getOptionalNMS("").orElse(null);
+		STRUCTURE_BLOCK_UPDATE_TYPE_CLASS = MinecraftReflection.getOptionalNMS("").orElse(null);
+		STRUCTURE_MODE_CLASS = MinecraftReflection.getOptionalNMS("").orElse(null);
+		CUSTOM_CHAT_COMPLETION_ACTION_CLASS = MinecraftReflection.getOptionalNMS("").orElse(null);
+		RECIPE_UPDATE_STATE_CLASS = MinecraftReflection.getOptionalNMS("").orElse(null);
+		OBJECTIVE_RENDER_TYPE_CLASS = MinecraftReflection.getOptionalNMS("").orElse(null);
 
 		associate(PROTOCOL_CLASS, Protocol.class, getProtocolConverter());
 		associate(CLIENT_COMMAND_CLASS, ClientCommand.class, getClientCommandConverter());
@@ -638,6 +654,30 @@ public abstract class EnumWrappers {
 		}
 		if (RECIPE_BOOK_TYPE_CLASS != null) {
 			associate(RECIPE_BOOK_TYPE_CLASS, RecipeBookType.class, getRecipeBookTypeConverter());
+		}
+		if(HUMANOID_ARM_CLASS != null) {
+			associate(HUMANOID_ARM_CLASS, HumanoidArm.class, getHumanoidArmConverter());
+		}
+		if (JOINT_TYPE_CLASS != null) {
+			associate(JOINT_TYPE_CLASS, JointType.class, getJointTypeConverter());
+		}
+		if (COMMAND_BLOCK_MODE_CLASS != null) {
+			associate(COMMAND_BLOCK_MODE_CLASS, CommandBlockMode.class, getCommandBlockModeConverter());
+		}
+		if (STRUCTURE_BLOCK_UPDATE_TYPE_CLASS  != null) {
+			associate(STRUCTURE_BLOCK_UPDATE_TYPE_CLASS, StructureBlockUpdateType.class, getStructureBlockUpdateTypeConverter());
+		}
+		if (STRUCTURE_MODE_CLASS != null) {
+			associate(STRUCTURE_MODE_CLASS, StructureMode.class, getStructureModeConverter());
+		}
+		if (CUSTOM_CHAT_COMPLETION_ACTION_CLASS != null) {
+			associate(CUSTOM_CHAT_COMPLETION_ACTION_CLASS, CustomChatTabCompletionsAction.class, getCustomChatCompletionActionConverter());
+		}
+		if (RECIPE_UPDATE_STATE_CLASS != null) {
+			associate(RECIPE_UPDATE_STATE_CLASS, RecipeUpdateState.class, getRecipeUpdateStateConverter());
+		}
+		if (OBJECTIVE_RENDER_TYPE_CLASS != null) {
+			associate(OBJECTIVE_RENDER_TYPE_CLASS, ObjectiveRenderType.class, getObjectiveRenderTypeConverter());
 		}
 	}
 
@@ -796,6 +836,46 @@ public abstract class EnumWrappers {
 		return RECIPE_BOOK_TYPE_CLASS;
 	}
 
+	public static Class<?> getHumanoidArmClass() {
+		initialize();
+		return HUMANOID_ARM_CLASS;
+	}
+
+	public static Class<?> getCommandBlockModeClass() {
+		initialize();
+		return COMMAND_BLOCK_MODE_CLASS;
+	}
+
+	public static Class<?> getJointTypeClass() {
+		initialize();
+		return JOINT_TYPE_CLASS;
+	}
+
+	public static Class<?> getStructureBlockUpdateTypeClass() {
+		initialize();
+		return STRUCTURE_BLOCK_UPDATE_TYPE_CLASS;
+	}
+
+	public static Class<?> getStructureModeClass() {
+		initialize();
+		return STRUCTURE_MODE_CLASS;
+	}
+
+	public static Class<?> getCustomChatCompletionActionClass() {
+		initialize();
+		return CUSTOM_CHAT_COMPLETION_ACTION_CLASS;
+	}
+
+	public static Class<?> getRecipeUpdateStateClass() {
+		initialize();
+		return RECIPE_UPDATE_STATE_CLASS;
+	}
+
+	public static Class<?> getObjectiveRenderTypeClass() {
+		initialize();
+		return OBJECTIVE_RENDER_TYPE_CLASS;
+	}
+
 	// Get the converters
 	public static EquivalentConverter<Protocol> getProtocolConverter() {
 		return new EnumConverter<>(getProtocolClass(), Protocol.class);
@@ -876,7 +956,39 @@ public abstract class EnumWrappers {
 	public static EquivalentConverter<ChatType> getChatTypeConverter() {
 		return new EnumConverter<>(getChatTypeClass(), ChatType.class);
 	}
-	
+
+	public static EquivalentConverter<HumanoidArm> getHumanoidArmConverter() {
+		return new IndexedEnumConverter<>(getHumanoidArmClass(), HumanoidArm.class);
+	}
+
+	public static EquivalentConverter<CommandBlockMode> getCommandBlockModeConverter() {
+		return new IndexedEnumConverter<>(getCommandBlockModeClass(), CommandBlockMode.class);
+	}
+
+	public static EquivalentConverter<JointType> getJointTypeConverter() {
+		return new IndexedEnumConverter<>(getJointTypeClass(), JointType.class);
+	}
+
+	public static EquivalentConverter<StructureBlockUpdateType> getStructureBlockUpdateTypeConverter() {
+		return new IndexedEnumConverter<>(getStructureBlockUpdateTypeClass(), StructureBlockUpdateType.class);
+	}
+
+	public static EquivalentConverter<StructureMode> getStructureModeConverter() {
+		return new IndexedEnumConverter<>(getStructureModeClass(), StructureMode.class);
+	}
+
+	public static EquivalentConverter<CustomChatTabCompletionsAction> getCustomChatCompletionActionConverter() {
+		return new IndexedEnumConverter<>(getCustomChatCompletionActionClass(), CustomChatTabCompletionsAction.class);
+	}
+
+	public static EquivalentConverter<RecipeUpdateState> getRecipeUpdateStateConverter() {
+		return new IndexedEnumConverter<>(getRecipeUpdateStateClass(), RecipeUpdateState.class);
+	}
+
+	public static EquivalentConverter<ObjectiveRenderType> getObjectiveRenderTypeConverter() {
+		return new IndexedEnumConverter<>(getObjectiveRenderTypeClass(), ObjectiveRenderType.class);
+	}
+
 	/**
 	 * @since 1.13+
 	 * @return {@link EnumConverter} or null (if bellow 1.13 / nms EnumPose class cannot be found)
@@ -1075,18 +1187,19 @@ public abstract class EnumWrappers {
 		}
 	}
 
-	public static class IndexedEnumConverter<T extends Enum<T>> implements EquivalentConverter<T> {
-		private Class<T> specificClass;
+	public static class IndexedEnumConverter<T> implements EquivalentConverter<T> {
+		private Class<?> specificClass;
 		private Class<?> genericClass;
 
-		public IndexedEnumConverter(Class<T> specificClass, Class<?> genericClass) {
+		public IndexedEnumConverter(Class<?> specificClass, Class<?> genericClass) {
 			this.specificClass = specificClass;
 			this.genericClass = genericClass;
 		}
 
 		@Override
 		public Object getGeneric(T specific) {
-			int ordinal = specific.ordinal();
+			Enum<?> en = (Enum) specific;
+			int ordinal = en.ordinal();
 			for (Object elem : genericClass.getEnumConstants()) {
 				if (((Enum<?>) elem).ordinal() == ordinal) {
 					return elem;
@@ -1099,9 +1212,9 @@ public abstract class EnumWrappers {
 		@Override
 		public T getSpecific(Object generic) {
 			int ordinal = ((Enum<?>) generic).ordinal();
-			for (T elem : specificClass.getEnumConstants()) {
-				if (elem.ordinal() == ordinal) {
-					return elem;
+			for (Object elem : specificClass.getEnumConstants()) {
+				if (((Enum) elem).ordinal() == ordinal) {
+					return (T) elem;
 				}
 			}
 
@@ -1109,7 +1222,7 @@ public abstract class EnumWrappers {
 		}
 
 		@Override
-		public Class<T> getSpecificType() {
+		public Class getSpecificType() {
 			return specificClass;
 		}
 	}

--- a/src/main/java/com/comphenix/protocol/wrappers/Vector3I.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/Vector3I.java
@@ -1,0 +1,62 @@
+/**
+ * (c) 2016 dmulloy2
+ */
+package com.comphenix.protocol.wrappers;
+
+import com.comphenix.protocol.reflect.EquivalentConverter;
+import com.comphenix.protocol.reflect.accessors.Accessors;
+import com.comphenix.protocol.reflect.accessors.ConstructorAccessor;
+import com.comphenix.protocol.reflect.accessors.FieldAccessor;
+import com.comphenix.protocol.utility.MinecraftReflection;
+
+public class Vector3I extends AbstractWrapper {
+    public final static Class<?> HANDLE_TYPE = MinecraftReflection.getMinecraftClass("core.BaseBlockPosition", "core.Vec3i");
+    private static FieldAccessor FIELD_X_ACCESSOR = Accessors.getFieldAccessorArray(HANDLE_TYPE, int.class, true)[0];
+    private static FieldAccessor FIELD_Y_ACCESSOR = Accessors.getFieldAccessorArray(HANDLE_TYPE, int.class, true)[1];
+    private static FieldAccessor FIELD_Z_ACCESSOR = Accessors.getFieldAccessorArray(HANDLE_TYPE, int.class, true)[2];
+    private static ConstructorAccessor CONSTRUCTOR = null;
+
+    public Vector3I(Object handle) {
+        super(HANDLE_TYPE);
+        this.setHandle(handle);
+    }
+
+    public static Vector3I newInstance(int x, int y, int z) {
+        if (CONSTRUCTOR == null) {
+            CONSTRUCTOR = Accessors.getConstructorAccessor(HANDLE_TYPE, int.class, int.class, int.class);
+        }
+        return new Vector3I(CONSTRUCTOR.invoke(x, y, z));
+    }
+
+
+    public int getX() {
+        return (int) FIELD_X_ACCESSOR.get(handle);
+    }
+
+    public Vector3I setX(int x) {
+        FIELD_X_ACCESSOR.set(handle, x);
+        return this;
+    }
+
+    public int getY() {
+        return (int) FIELD_Y_ACCESSOR.get(handle);
+    }
+
+    public Vector3I setY(int y) {
+        FIELD_Y_ACCESSOR.set(handle, y);
+        return this;
+    }
+
+    public int getZ() {
+        return (int) FIELD_Z_ACCESSOR.get(handle);
+    }
+
+    public Vector3I setZ(int z) {
+        FIELD_Z_ACCESSOR.set(handle, z);
+        return this;
+    }
+
+    public static EquivalentConverter<Vector3I> getConverter() {
+        return Converters.ignoreNull(Converters.handle(Vector3I::getHandle, Vector3I::new, Vector3I.class));
+    }
+}

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedDataValue.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedDataValue.java
@@ -6,6 +6,9 @@ import com.comphenix.protocol.reflect.accessors.ConstructorAccessor;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher.Registry;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher.Serializer;
+import com.google.common.base.Preconditions;
+
+import java.util.Optional;
 
 /**
  * Represents a DataValue in 1.19.3+.
@@ -24,11 +27,18 @@ public class WrappedDataValue extends AbstractWrapper {
 	 * @param handle the wrapped data value.
 	 */
 	public WrappedDataValue(Object handle) {
-		super(HANDLE_TYPE);
+		super(Preconditions.checkNotNull(HANDLE_TYPE, "Cannot find handle type for WrappedDataValue. WrappedDataValue is only supported for Minecraft 1.19.3 or later."));
 		this.setHandle(handle);
 		this.modifier = new StructureModifier<>(this.handleType).withTarget(handle);
 	}
 
+	/**
+	 * Constructs a new WrappedDataValue
+	 * If a ProtocolLib Wrapper is provided for the param 'value', it will be unwrapped automatically
+	 * @param index index of the metadata
+	 * @param serializer serializer corresponding to the data type of this value
+	 * @param value the NMS handle.
+	 */
 	public WrappedDataValue(int index, Serializer serializer, Object value) {
 		this(newHandle(index, serializer, value));
 	}
@@ -67,18 +77,36 @@ public class WrappedDataValue extends AbstractWrapper {
 		this.modifier.writeSafely(1, serializer == null ? null : serializer.getHandle());
 	}
 
+	/**
+	 * Retrieves the value associated to this WrappedDataValue. Supported NMS objects will be implicitly wrapped to ProtocolLib wrappers.
+	 * For example, if a IChatBaseComponent is stored in this DataValue, this will automatically wrap it to a WrappedChatComponent.
+	 * @return Associated value, possible wrapped
+	 */
 	public Object getValue() {
 		return WrappedWatchableObject.getWrapped(getRawValue());
 	}
 
+	/**
+	 * Updates the value of this DataValue. If the provided value is a ProtocolLib wrapper, it will be unwrapped
+	 * implicitly.
+	 */
 	public void setValue(Object value) {
 		setRawValue(WrappedWatchableObject.getUnwrapped(value));
 	}
 
+	/**
+	 * Returns the raw value associated to this DataValue.
+	 * This will not return any ProtocolLib wrappers, e.g., it returns a IChatBaseComponent instead of a WrappedChatComponent.
+	 * @return raw object value
+	 */
 	public Object getRawValue() {
 		return this.modifier.readSafely(2);
 	}
 
+	/**
+	 * Updates the raw value associated to this DataValue.
+	 * @param value raw value
+	 */
 	public void setRawValue(Object value) {
 		this.modifier.writeSafely(2, value);
 	}

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedFilterMask.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedFilterMask.java
@@ -1,0 +1,78 @@
+package com.comphenix.protocol.wrappers;
+
+import com.comphenix.protocol.reflect.EquivalentConverter;
+import com.comphenix.protocol.reflect.accessors.Accessors;
+import com.comphenix.protocol.reflect.accessors.ConstructorAccessor;
+import com.comphenix.protocol.reflect.accessors.FieldAccessor;
+import com.comphenix.protocol.utility.MinecraftReflection;
+
+import java.util.BitSet;
+
+/**
+ * @author Lukas Alt
+ * @since 06.05.2023
+ */
+public class WrappedFilterMask extends AbstractWrapper {
+    public final static Class<?> HANDLE_CLASS = MinecraftReflection.getMinecraftClass("network.chat.FilterMask");
+    private final static Class<?> TYPE_CLASS = MinecraftReflection.getMinecraftClass("network.chat.FilterMask.Type");
+    private static FieldAccessor MASK_ACCESSOR = Accessors.getFieldAccessor(HANDLE_CLASS, BitSet.class, true);
+    private static FieldAccessor TYPE_ACCESSOR = Accessors.getFieldAccessor(HANDLE_CLASS, TYPE_CLASS, true);
+    private static ConstructorAccessor CONSTRUCTOR_ACCESSOR;
+
+    public WrappedFilterMask(Object handle) {
+        super(HANDLE_CLASS);
+        this.setHandle(handle);
+    }
+
+    public static WrappedFilterMask newInstance(BitSet bitSet, Type type) {
+        if(CONSTRUCTOR_ACCESSOR == null) {
+            CONSTRUCTOR_ACCESSOR = Accessors.getConstructorAccessor(HANDLE_CLASS, BitSet.class, TYPE_CLASS);
+        }
+        return new WrappedFilterMask(CONSTRUCTOR_ACCESSOR.invoke(bitSet, type));
+    }
+
+    public BitSet getMask() {
+        return (BitSet) MASK_ACCESSOR.get(handle);
+    }
+
+    public void setMask(BitSet bitSet) {
+        MASK_ACCESSOR.set(handle, bitSet);
+    }
+
+    public Type getType() {
+        return (Type) TYPE_ACCESSOR.get(handle);
+    }
+
+    public void setType(Type type) {
+        TYPE_ACCESSOR.set(handle, type);
+    }
+
+    public enum Type {
+        PASS_THROUGH,
+        FULLY_FILTERED,
+        PARTIALLY_FILTERED;
+
+        public static EquivalentConverter<Type> getConverter() {
+            return new EnumWrappers.IndexedEnumConverter<>(TYPE_CLASS, Type.class);
+        }
+    }
+
+    public static EquivalentConverter<WrappedFilterMask> getConverter() {
+        return new EquivalentConverter<WrappedFilterMask>() {
+            @Override
+            public Object getGeneric(WrappedFilterMask specific) {
+                return specific.getHandle();
+            }
+
+            @Override
+            public WrappedFilterMask getSpecific(Object generic) {
+                return new WrappedFilterMask(generic);
+            }
+
+            @Override
+            public Class<WrappedFilterMask> getSpecificType() {
+                return WrappedFilterMask.class;
+            }
+        };
+    }
+}

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedFilterMask.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedFilterMask.java
@@ -14,7 +14,7 @@ import java.util.BitSet;
  */
 public class WrappedFilterMask extends AbstractWrapper {
     public final static Class<?> HANDLE_CLASS = MinecraftReflection.getMinecraftClass("network.chat.FilterMask");
-    private final static Class<?> TYPE_CLASS = MinecraftReflection.getMinecraftClass("network.chat.FilterMask.Type");
+    private final static Class<?> TYPE_CLASS = MinecraftReflection.getMinecraftClass("network.chat.FilterMask$Type", "network.chat.FilterMask$a");
     private static FieldAccessor MASK_ACCESSOR = Accessors.getFieldAccessor(HANDLE_CLASS, BitSet.class, true);
     private static FieldAccessor TYPE_ACCESSOR = Accessors.getFieldAccessor(HANDLE_CLASS, TYPE_CLASS, true);
     private static ConstructorAccessor CONSTRUCTOR_ACCESSOR;
@@ -28,7 +28,7 @@ public class WrappedFilterMask extends AbstractWrapper {
         if(CONSTRUCTOR_ACCESSOR == null) {
             CONSTRUCTOR_ACCESSOR = Accessors.getConstructorAccessor(HANDLE_CLASS, BitSet.class, TYPE_CLASS);
         }
-        return new WrappedFilterMask(CONSTRUCTOR_ACCESSOR.invoke(bitSet, type));
+        return new WrappedFilterMask(CONSTRUCTOR_ACCESSOR.invoke(bitSet, Type.getConverter().getGeneric(type)));
     }
 
     public BitSet getMask() {
@@ -53,7 +53,7 @@ public class WrappedFilterMask extends AbstractWrapper {
         PARTIALLY_FILTERED;
 
         public static EquivalentConverter<Type> getConverter() {
-            return new EnumWrappers.IndexedEnumConverter<>(TYPE_CLASS, Type.class);
+            return new EnumWrappers.IndexedEnumConverter<>(Type.class, TYPE_CLASS);
         }
     }
 

--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedPacketDataSerializer.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedPacketDataSerializer.java
@@ -1,0 +1,64 @@
+package com.comphenix.protocol.wrappers;
+
+import com.comphenix.protocol.reflect.EquivalentConverter;
+import com.comphenix.protocol.reflect.accessors.Accessors;
+import com.comphenix.protocol.reflect.accessors.ConstructorAccessor;
+import com.comphenix.protocol.reflect.accessors.FieldAccessor;
+import com.comphenix.protocol.utility.MinecraftReflection;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import javax.annotation.Nonnull;
+
+public class WrappedPacketDataSerializer extends AbstractWrapper {
+    public final static Class<?> PACKET_DATA_SERIALIZER_CLASS = MinecraftReflection.getPacketDataSerializerClass();
+    private final static FieldAccessor BUFFER_ACCESSOR = Accessors.getFieldAccessor(PACKET_DATA_SERIALIZER_CLASS, MinecraftReflection.getByteBufClass(), true);
+    private static ConstructorAccessor CONSTRUCTOR;
+    /**
+     * Construct a new NMS wrapper.
+     *
+     * @param handle - the NMS handle.
+     */
+    public WrappedPacketDataSerializer(Object handle) {
+        super(PACKET_DATA_SERIALIZER_CLASS);
+        this.setHandle(handle);
+    }
+
+    public ByteBuf getBuffer() {
+        return (ByteBuf) BUFFER_ACCESSOR.get(handle);
+    }
+
+    public void setBuffer(@Nonnull ByteBuf buf) {
+        BUFFER_ACCESSOR.set(handle, buf);
+    }
+
+    public static WrappedPacketDataSerializer fromHandle(Object handle) {
+        return new WrappedPacketDataSerializer(handle);
+    }
+
+    public static WrappedPacketDataSerializer newBuffer() {
+        if(CONSTRUCTOR == null) {
+            CONSTRUCTOR = Accessors.getConstructorAccessor(PACKET_DATA_SERIALIZER_CLASS, ByteBuf.class);
+        }
+        return fromHandle(CONSTRUCTOR.invoke(Unpooled.buffer()));
+    }
+
+    public static EquivalentConverter<WrappedPacketDataSerializer> getConverter() {
+        return new EquivalentConverter<WrappedPacketDataSerializer>() {
+            @Override
+            public Object getGeneric(WrappedPacketDataSerializer specific) {
+                return specific.getHandle();
+            }
+
+            @Override
+            public WrappedPacketDataSerializer getSpecific(Object generic) {
+                return WrappedPacketDataSerializer.fromHandle(generic);
+            }
+
+            @Override
+            public Class<WrappedPacketDataSerializer> getSpecificType() {
+                return WrappedPacketDataSerializer.class;
+            }
+        };
+    }
+}

--- a/src/test/java/com/comphenix/protocol/wrappers/Vector3ITest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/Vector3ITest.java
@@ -1,0 +1,34 @@
+package com.comphenix.protocol.wrappers;
+
+import com.comphenix.protocol.BukkitInitialization;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Lukas Alt
+ * @since 06.05.2023
+ */
+class Vector3ITest {
+
+    @BeforeAll
+    public static void beforeAll() {
+        BukkitInitialization.initializeAll();
+    }
+
+    @Test
+    public void test() {
+        Vector3I vector3I = Vector3I.newInstance(1, 2, 3);
+        assertEquals(1, vector3I.getX());
+        assertEquals(2, vector3I.getY());
+        assertEquals(3, vector3I.getZ());
+        vector3I.setX(4);
+        vector3I.setY(5);
+        vector3I.setZ(6);
+        assertEquals(4, vector3I.getX());
+        assertEquals(5, vector3I.getY());
+        assertEquals(6, vector3I.getZ());
+        Object generic = Vector3I.getConverter().getGeneric(vector3I);
+        assertEquals(vector3I, Vector3I.getConverter().getSpecific(generic));
+    }
+}

--- a/src/test/java/com/comphenix/protocol/wrappers/WrappedFilterMaskTest.java
+++ b/src/test/java/com/comphenix/protocol/wrappers/WrappedFilterMaskTest.java
@@ -1,0 +1,28 @@
+package com.comphenix.protocol.wrappers;
+
+import com.comphenix.protocol.BukkitInitialization;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.BitSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Lukas Alt
+ * @since 06.05.2023
+ */
+class WrappedFilterMaskTest {
+    @BeforeAll
+    public static void initializeBukkit() {
+        BukkitInitialization.initializeAll();
+    }
+
+    @Test
+    public void testFilterMask() {
+        WrappedFilterMask filterMask = WrappedFilterMask.newInstance(new BitSet(20), WrappedFilterMask.Type.PARTIALLY_FILTERED);
+        Object generic = WrappedFilterMask.getConverter().getGeneric(filterMask);
+        WrappedFilterMask specific = WrappedFilterMask.getConverter().getSpecific(generic);
+        assertEquals(filterMask, specific);
+    }
+
+}


### PR DESCRIPTION
Currently, lots of wrappers are missing for new field types in packets for 1.19 and later.  I started implementing some of them (mainly enums) and generated a list of NMS classes that currently do not have a corresponding wrapper. Please note that this is still a work in progress.

- [x] net.minecraft.network.protocol.game.ClientboundRecipePacket$State
- [ ] net.minecraft.stats.RecipeBookSettings
- [x] net.minecraft.network.chat.LastSeenMessages$Update
- [ ] net.minecraft.commands.arguments.ArgumentSignatures
- [x] net.minecraft.world.level.block.entity.JigsawBlockEntity$JointType
- [x] net.minecraft.world.entity.HumanoidArm
- [x] net.minecraft.world.level.block.entity.StructureBlockEntity$UpdateType
- [x] net.minecraft.world.level.block.state.properties.StructureMode
- [x] net.minecraft.core.Vec3i
- [ ] net.minecraft.world.level.block.Mirror
- [ ] net.minecraft.world.level.block.Rotation
- [x] net.minecraft.network.protocol.game.ServerboundInteractPacket$Action
- [x] net.minecraft.world.inventory.ClickType
- [ ] net.minecraft.network.protocol.game.ClientboundBossEventPacket$Operation
- [ ] net.minecraft.network.chat.SignedMessageBody$Packed
- [x] net.minecraft.network.chat.FilterMask
- [ ] net.minecraft.network.chat.ChatType$BoundNetwork
- [x] net.minecraft.network.protocol.game.ClientboundCustomChatCompletionsPacket$Action
- [ ] net.minecraft.network.chat.MessageSignature$Packed
- [ ] net.minecraft.world.effect.MobEffectInstance$FactorData
- [ ] net.minecraft.core.RegistryAccess$Frozen
- [ ] net.minecraft.commands.arguments.EntityAnchorArgument$Anchor
- [ ] net.minecraft.world.level.saveddata.maps.MapItemSavedData$MapPatch
- [x] net.minecraft.network.protocol.game.ClientboundRecipePacket$State
- [ ] net.minecraft.stats.RecipeBookSettings
- [x] net.minecraft.world.scores.criteria.ObjectiveCriteria$RenderType
- [ ] net.minecraft.network.protocol.game.ClientboundSetPlayerTeamPacket.Parameters
- [ ] com.mojang.brigadier.suggestion.Suggestions
- [x] net.minecraft.world.level.block.entity.BlockEntityType (#2111)
- [x] net.minecraft.world.item.Item
- [x] net.minecraft.network.FriendlyByteBuf