### PR TITLE
Ignore static fields in wrapper class for AutoWrapper

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/AutoWrapper.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AutoWrapper.java
@@ -151,6 +151,7 @@ public class AutoWrapper<T> implements EquivalentConverter<T> {
         if (wrapperAccessors == null) {
             wrapperAccessors = Arrays
                     .stream(wrapperClass.getDeclaredFields())
+                    .filter(field -> !Modifier.isStatic(field.getModifiers()))
                     .map(Accessors::getFieldAccessor)
                     .toArray(FieldAccessor[]::new);
         }


### PR DESCRIPTION
The `AutoWrapper` currently does not ignore static fields in wrapper classes leading to problems if a wrapper class has some static constant.