### PR TITLE
DetailedErrorReporter: Log error even if config is null

### DIFF
--- a/src/main/java/com/comphenix/protocol/error/DetailedErrorReporter.java
+++ b/src/main/java/com/comphenix/protocol/error/DetailedErrorReporter.java
@@ -391,7 +391,8 @@ public class DetailedErrorReporter implements ErrorReporter {
             writer.println(addPrefix(Bukkit.getServer().getVersion(), SECOND_LEVEL_PREFIX));
 
             // Inform of this occurrence
-            if (ERROR_PERMISSION != null && ProtocolLibrary.getConfig().isChatWarnings()) {
+            ProtocolConfig config = ProtocolLibrary.getConfig();
+            if (ERROR_PERMISSION != null && config != null && config.isChatWarnings())) {
                 Bukkit.getServer().broadcast(
                         String.format("Error %s (%s) occurred in %s.", report.getReportMessage(), report.getException(), sender),
                         ERROR_PERMISSION


### PR DESCRIPTION
When an error occurs during the initialization process of the plugin, resulting in a null configuration, the accurate error is not logged. This fix that.

```
java.lang.NullPointerException: Cannot invoke "com.comphenix.protocol.ProtocolConfig.isChatWarnings()" because the return value of "com.comphenix.protocol.ProtocolLibrary.getConfig()" is null
	at com.comphenix.protocol.error.DetailedErrorReporter.reportDetailed(DetailedErrorReporter.java:394) ~[ProtocolLib.jar:?]
	at com.comphenix.protocol.error.DelegatedErrorReporter.reportDetailed(DelegatedErrorReporter.java:63) ~[ProtocolLib.jar:?]
	at com.comphenix.protocol.error.DelegatedErrorReporter.reportDetailed(DelegatedErrorReporter.java:87) ~[ProtocolLib.jar:?]
	at com.comphenix.protocol.ProtocolLib.onLoad(ProtocolLib.java:186) ~[ProtocolLib.jar:?]
	at io.papermc.paper.plugin.storage.ServerPluginProviderStorage.processProvided(ServerPluginProviderStorage.java:59) ~[paper.jar:git-Paper-546]
	at io.papermc.paper.plugin.storage.ServerPluginProviderStorage.processProvided(ServerPluginProviderStorage.java:18) ~[paper.jar:git-Paper-546]
	at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:40) ~[paper.jar:git-Paper-546]
	at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:36) ~[paper.jar:git-Paper-546]
	at org.bukkit.craftbukkit.v1_19_R3.CraftServer.loadPlugins(CraftServer.java:426) ~[paper.jar:git-Paper-546]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:273) ~[paper.jar:git-Paper-546]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1104) ~[paper.jar:git-Paper-546]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:320) ~[paper.jar:git-Paper-546]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
<img width="849" alt="image" src="https://github.com/dmulloy2/ProtocolLib/assets/15692249/a3a0eebb-bd94-4a7e-9ccb-ba2480d46329">

