### PR TITLE
Fix metrics scheduler for Folia

### DIFF
--- a/src/main/java/com/comphenix/protocol/metrics/Metrics.java
+++ b/src/main/java/com/comphenix/protocol/metrics/Metrics.java
@@ -1,9 +1,9 @@
 package com.comphenix.protocol.metrics;
 
+import com.comphenix.protocol.ProtocolLib;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.ServicePriority;
 import org.json.simple.JSONArray;
@@ -56,7 +56,7 @@ public class Metrics {
     private static String serverUUID;
 
     // The plugin
-    private final Plugin plugin;
+    private final ProtocolLib plugin;
 
     // A list with all custom charts
     private final List<CustomChart> charts = new ArrayList<>();
@@ -66,7 +66,7 @@ public class Metrics {
      *
      * @param plugin The plugin which stats should be submitted.
      */
-    public Metrics(Plugin plugin) {
+    public Metrics(ProtocolLib plugin) {
         if (plugin == null) {
             throw new IllegalArgumentException("Plugin cannot be null!");
         }
@@ -151,7 +151,7 @@ public class Metrics {
                 }
                 // Nevertheless we want our code to run in the Bukkit main thread, so we have to use the Bukkit scheduler
                 // Don't be afraid! The connection to the bStats server is still async, only the stats collection is sync ;)
-                Bukkit.getScheduler().runTask(plugin, Metrics.this::submitData);
+                plugin.getScheduler().runTask(Metrics.this::submitData);
             }
         }, 1000L * 60 * 5, 1000L * 60 * 30);
         // Submit the data every 30 minutes, first time after 5 minutes to give other plugins enough time to start


### PR DESCRIPTION
Use ProtocolScheduler to support Folia

Fixes #2448, #2447

Also, I wanted to ask what is still missing for the ProtocolLib 5.1.0 release?