### PR TITLE
FIX wiki.vg uri

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 Certain tasks are impossible to perform with the standard Bukkit API, and may require
 working with and even modifying Minecraft directly. A common technique is to modify incoming
-and outgoing [packets](https://www.wiki.vg/Protocol), or inject custom packets into the
+and outgoing [packets](https://wiki.vg/Protocol), or inject custom packets into the
 stream. This is quite cumbersome to do, however, and most implementations will break
 as soon as a new version of Minecraft has been released, mostly due to obfuscation.
 


### PR DESCRIPTION
When accessing the URI for the protocol it displays the following message:

![image](https://github.com/dmulloy2/ProtocolLib/assets/45739045/2cbec085-84c7-4bf2-a159-213a9e52f359)

This is due to the certificate being for the invalid domain `ark.tkte.ch`

# Fix

Just point to `https://wiki.vg` rather than `https://www.wiki.vg`