### PR TITLE
Added a null check for the optional converter

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/Converters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/Converters.java
@@ -168,6 +168,7 @@ public class Converters {
 
             @Override
             public Optional<T> getSpecific(Object generic) {
+                if (generic == null) return Optional.empty();
                 Optional<Object> optional = (Optional<Object>) generic;
                 return optional.map(converter::getSpecific);
             }


### PR DESCRIPTION
I was using ProtocolLib on my plugin and I was getting some interesting errors on Scoreboard Team Packet, I found that the optional is null for some reason and causes a NPE, it seems that some Teams will not contain nothing, so I added a null check for the generic and returned a empty optional, Error that I got:
`
java.lang.NullPointerException: Cannot invoke "java.util.Optional.map(java.util.function.Function)" because "optional" is null
at com.comphenix.protocol.wrappers.Converters$5.getSpecific(Converters.java:172) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.wrappers.Converters$5.getSpecific(Converters.java:163) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.reflect.StructureModifier.readInternal(StructureModifier.java:301) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.reflect.StructureModifier.read(StructureModifier.java:251) ~[ProtocolLib.jar:?]
at me.doublenico.hypegradients.wrappers.scoreboard.WrapperScoreboardTeam.getPrefix(WrapperScoreboardTeam.java:45) ~[HypeGradients-1.0.8.jar:?]
at me.doublenico.hypegradients.packets.scoreboard.ScoreboardTeamPacket.onPacketSending(ScoreboardTeamPacket.java:35) ~[HypeGradients-1.0.8.jar:?]
at me.doublenico.hypegradients.api.packet.MessagePacketHandler$2.onPacketSending(MessagePacketHandler.java:73) ~[HypeGradients-1.0.8.jar:?]
at com.comphenix.protocol.injector.SortedPacketListenerList.invokeSendingListener(SortedPacketListenerList.java:219) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.SortedPacketListenerList.invokeUnpackedPacketSending(SortedPacketListenerList.java:204) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.SortedPacketListenerList.invokePacketSending(SortedPacketListenerList.java:149) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.SortedPacketListenerList.invokePacketSending(SortedPacketListenerList.java:139) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.PacketFilterManager.postPacketToListeners(PacketFilterManager.java:555) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.PacketFilterManager.invokePacketSending(PacketFilterManager.java:528) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.netty.manager.NetworkManagerInjector.onPacketSending(NetworkManagerInjector.java:100) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.netty.channel.NettyChannelInjector.processOutbound(NettyChannelInjector.java:566) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.netty.channel.NettyChannelInjector$2.doProxyRunnable(NettyChannelInjector.java:467) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.netty.channel.NettyEventLoopProxy.proxyRunnable(NettyEventLoopProxy.java:43) ~[ProtocolLib.jar:?]
at com.comphenix.protocol.injector.netty.channel.NettyEventLoopProxy.execute(NettyEventLoopProxy.java:252) ~[ProtocolLib.jar:?]
at net.minecraft.network.Connection.sendPacket(Connection.java:440) ~[?:?]
at net.minecraft.network.Connection.processQueue(Connection.java:557) ~[?:?]
at net.minecraft.network.Connection.flushQueue(Connection.java:513) ~[?:?]
at net.minecraft.network.Connection.tick(Connection.java:577) ~[?:?]
at net.minecraft.server.network.ServerConnectionListener.tick(ServerConnectionListener.java:234) ~[?:?]
at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1605) ~[purpur-1.19.4.jar:git-Purpur-1985]
at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:488) ~[purpur-1.19.4.jar:git-Purpur-1985]
at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1424) ~[purpur-1.19.4.jar:git-Purpur-1985]
at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1195) ~[purpur-1.19.4.jar:git-Purpur-1985]
at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:325) ~[purpur-1.19.4.jar:git-Purpur-1985]
at java.lang.Thread.run(Thread.java:1623) ~[?:?]
[20:19:17] [Server thread/ERROR]: Parameters:
net.minecraft.network.protocol.game.PacketPlayOutScoreboardTeam@2a21453b[
h=1
i=ASB-4
j=<null>
k=<null>
]
`