### PR TITLE
Proposal to change async packet processing logic

### DIFF
--- a/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
@@ -413,6 +413,19 @@ public class AsyncFilterManager implements AsynchronousManager {
         
         // Only send if the packet is ready
         if (marker.decrementProcessingDelay() == 0) {
+
+            // Now, get the next non-cancelled listener
+            if (!marker.hasExpired()) {
+                for (; marker.getListenerTraversal().hasNext(); ) {
+                    AsyncListenerHandler handler = marker.getListenerTraversal().next().getListener();
+                    
+                    if (!handler.isCancelled()) {
+                        getProcessingQueue(packet).enqueue(packet, onMainThread);
+                        return;
+                    }
+                }
+            }
+
             PacketSendingQueue queue = getSendingQueue(packet, false);
             
             // No need to create a new queue if the player has logged out

--- a/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
@@ -420,11 +420,15 @@ public class AsyncFilterManager implements AsynchronousManager {
                     AsyncListenerHandler handler = marker.getListenerTraversal().next().getListener();
                     
                     if (!handler.isCancelled()) {
-                        getProcessingQueue(packet).enqueue(packet, onMainThread);
+                    	marker.incrementProcessingDelay();
+                    	handler.enqueuePacket(packet);
                         return;
                     }
                 }
             }
+            
+            // There are no more listeners - queue the packet for transmission
+            signalFreeProcessingSlot(packet);
 
             PacketSendingQueue queue = getSendingQueue(packet, false);
             

--- a/src/main/java/com/comphenix/protocol/async/AsyncListenerHandler.java
+++ b/src/main/java/com/comphenix/protocol/async/AsyncListenerHandler.java
@@ -632,9 +632,6 @@ public class AsyncListenerHandler {
             filterManager.getErrorReporter().reportMinimal(listener.getPlugin(), methodName, e);
         }
         
-        // There are no more listeners - queue the packet for transmission
-        filterManager.signalFreeProcessingSlot(packet);
-        
         // Note that listeners can opt to delay the packet transmission
         filterManager.signalPacketTransmission(packet);
     }

--- a/src/main/java/com/comphenix/protocol/async/AsyncListenerHandler.java
+++ b/src/main/java/com/comphenix/protocol/async/AsyncListenerHandler.java
@@ -632,18 +632,6 @@ public class AsyncListenerHandler {
             filterManager.getErrorReporter().reportMinimal(listener.getPlugin(), methodName, e);
         }
         
-        // Now, get the next non-cancelled listener
-        if (!marker.hasExpired()) {
-            for (; marker.getListenerTraversal().hasNext(); ) {
-                AsyncListenerHandler handler = marker.getListenerTraversal().next().getListener();
-                
-                if (!handler.isCancelled()) {
-                    handler.enqueuePacket(packet);
-                    return;
-                }
-            }
-        }
-        
         // There are no more listeners - queue the packet for transmission
         filterManager.signalFreeProcessingSlot(packet);
         

--- a/src/main/java/com/comphenix/protocol/async/PacketProcessingQueue.java
+++ b/src/main/java/com/comphenix/protocol/async/PacketProcessingQueue.java
@@ -131,30 +131,18 @@ class PacketProcessingQueue extends AbstractConcurrentListenerMultimap<AsyncList
             if (holder != null) {
                 PacketEvent packet = holder.getEvent();
                 AsyncMarker marker = packet.getAsyncMarker();
-                Iterator<PrioritizedListener<AsyncListenerHandler>> iterator = marker.getListenerTraversal();
+                Collection<PrioritizedListener<AsyncListenerHandler>> list = getListener(packet.getPacketType());
                 
                 marker.incrementProcessingDelay();
                 
-                if (iterator != null && iterator.hasNext()) {
-                    AsyncListenerHandler handler = marker.getListenerTraversal().next().getListener();
-                    if (!handler.isCancelled()) {
-                        handler.enqueuePacket(packet);
+                // Yes, removing the marker will cause the chain to stop
+                if (list != null) {
+                    Iterator<PrioritizedListener<AsyncListenerHandler>> iterator = list.iterator();
+                    
+                    if (iterator.hasNext()) {
+                        marker.setListenerTraversal(iterator);
+                        iterator.next().getListener().enqueuePacket(packet);
                         continue;
-                    }
-                }
-
-                if (iterator == null) {
-                    Collection<PrioritizedListener<AsyncListenerHandler>> list = getListener(packet.getPacketType());
-
-                    // Yes, removing the marker will cause the chain to stop
-                    if (list != null) {
-                        iterator = list.iterator();
-                        
-                        if (iterator.hasNext()) {
-                            marker.setListenerTraversal(iterator);
-                            iterator.next().getListener().enqueuePacket(packet);
-                            continue;
-                        }
                     }
                 }
                 


### PR DESCRIPTION
I got recently confronted with an incompatibility between my plugin [Orebufscator](https://github.com/Imprex-Development/orebfuscator) and [RealisticSeasons](https://www.spigotmc.org/resources/realisticseasons-1-16-3-1-20-1-seasons-in-your-minecraft-world-with-temperature-and-calendar.93275/). Both plugins are using async packet processing and delay the packet events (increase the processing delay). The way multiple async packet listeners are currently handled is as follows:

1. get all async listeners for the packet type
2. create an iterator for said list and attach it to the event
3. enqueue packet into first listener of iterator
4. processes packet (sync only)
5. enqueue packet into next listener of iterator
6. process packet (sync only)
7. goto step 5 if iterator isn't empty
8. mark processing slot free and try send packet if processing delay hit zero

This means if the first listener increases the processing delay then the second listener will process the same packet in parallel. The only way listeners can acquire exclusive access to a packet is using the `processingLock` object of the packet's `AsyncMarker`. This way of handling multi-threaded access to the packet event isn't very convenient since it could lead to unnecessary locked threads (if a listener would hold the lock for the entire processing step) and potential deadlocks if multiple packets are needed to process a single packet. This is especially harmful to the performance of plugins that process the packet in their own scheduler system (Orebfuscator does that because we need to jump back and forth between processing and main thread in some instances) because this could clog up the entire scheduler (particularly if a plugin needs a long time to process a packet). Furthermore there is currently a way for badly written plugins to prematurely send a packet through multiple decreasings of the processing delay without given other listeners time to process the packet.

That's why I propose the simple changes in this PR to effectively change steps 4 and 6 to also process the packet async (with processing delay reduced to zero) before calling the next listener. This way only one listener at a time can process a packet meaning the packet would always be "stable". Another way of solving this problem would be a new method for a listeners to explicitly tell ProtocolLib to only process this packet "sequentially" in that only this listener can process it and other listeners can after it's done. I would also be open for other solutions and would gladly implement them.