### PR TITLE
Fixed PING packet for 1.19.1 and 1.19.2

### DIFF
--- a/src/main/java/com/comphenix/protocol/PacketType.java
+++ b/src/main/java/com/comphenix/protocol/PacketType.java
@@ -352,7 +352,7 @@ public class PacketType implements Serializable, Cloneable, Comparable<PacketTyp
              * @deprecated Removed in 1.19.3
              */
             @Deprecated
-            public static final PacketType PLAYER_CHAT_HEADER =           new PacketType(PROTOCOL, SENDER, 0x32, "PlayerChatHeader");
+            public static final PacketType PLAYER_CHAT_HEADER =           new PacketType(PROTOCOL, SENDER, 0xF0, "PlayerChatHeader");
 
             /**
              * @deprecated Removed in 1.19.3


### PR DESCRIPTION
- [X] This issue is not solved in a development build

**Describe the bug**
When using PacketType.Play.Server.PING on versions using protocol number 760 (1.19.1, 1.19.2) it uses ClientboundPlayerChatHeaderPacket instead of ClientboundPingPacket due to using the same currentId on PING and deprecated PLAYER_CHAT_HEADER.

**To Reproduce**
Steps to reproduce the behavior:
1. Setup server on 1.19.1 or 1.19.2 version.
2. Try to check the name and name of the class it is using like this:
```
System.out.println(PacketType.Play.Server.PING.toString());
System.out.println(PacketType.Play.Server.PLAYER_CHAT_HEADER.toString());
```
3. See the mismatch in the console

**Expected behavior**
PacketType.Play.Server.PING should use ClientboundPingPacket.

**Screenshots**
Before changing currentId of PLAYER_CHAT_HEADER:
![Screenshot 2023-08-24 221131](https://github.com/dmulloy2/ProtocolLib/assets/78618405/c02cdbb1-2bf5-4135-9275-3052c3ab1ff2)

After changing currentId of PLAYER_CHAT_HEADER:
![Screenshot 2023-08-24 221503](https://github.com/dmulloy2/ProtocolLib/assets/78618405/7bad6458-9e21-4b1f-b888-ec0dabf65175)

**Version Info**
Before changing currentId of PLAYER_CHAT_HEADER:
https://pastebin.com/HBC3FW6D

After changing currentId of PLAYER_CHAT_HEADER:
https://pastebin.com/dEc91hxq

**Additional context**
In other versions it seems to work fine, but 1.19.1 and 1.19.2 is problematic.
