### PR TITLE
Fixed setting Base64 favicon for 1.19.4 or later

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -134,8 +134,7 @@ public class WrappedServerPing implements ClonableWrapper {
      * @return The favicon, or NULL if no favicon will be displayed.
      */
     public CompressedImage getFavicon() {
-        String favicon = impl.getFavicon();
-        return (favicon != null) ? CompressedImage.fromEncodedText(favicon) : null;
+        return impl.getFavicon();
     }
 
     /**
@@ -143,7 +142,7 @@ public class WrappedServerPing implements ClonableWrapper {
      * @param image - the new compressed image or NULL if no favicon should be displayed.
      */
     public void setFavicon(CompressedImage image) {
-        impl.setFavicon((image != null) ? image.toEncodedText() : null);
+        impl.setFavicon(image);
     }
 
     /**

--- a/src/main/java/com/comphenix/protocol/wrappers/ping/LegacyServerPing.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/ping/LegacyServerPing.java
@@ -155,8 +155,10 @@ public final class LegacyServerPing extends AbstractWrapper implements ServerPin
      * @return The favicon, or NULL if no favicon will be displayed.
      */
     @Override
-    public String getFavicon() {
-        return (String) FAVICON.get(handle);
+    public WrappedServerPing.CompressedImage getFavicon() {
+
+        String favicon = (String) FAVICON.get(handle);
+        return (favicon != null) ? WrappedServerPing.CompressedImage.fromEncodedText(favicon) : null;
     }
 
     /**
@@ -164,8 +166,8 @@ public final class LegacyServerPing extends AbstractWrapper implements ServerPin
      * @param image - the new compressed image or NULL if no favicon should be displayed.
      */
     @Override
-    public void setFavicon(String image) {
-        FAVICON.set(handle, image);
+    public void setFavicon(WrappedServerPing.CompressedImage image) {
+        FAVICON.set(handle, (image != null) ? image.toEncodedText() : null);
     }
 
     /**

--- a/src/main/java/com/comphenix/protocol/wrappers/ping/ServerPingImpl.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/ping/ServerPingImpl.java
@@ -2,6 +2,7 @@ package com.comphenix.protocol.wrappers.ping;
 
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
+import com.comphenix.protocol.wrappers.WrappedServerPing;
 import com.google.common.collect.ImmutableList;
 
 public interface ServerPingImpl extends Cloneable {
@@ -17,8 +18,8 @@ public interface ServerPingImpl extends Cloneable {
     void setVersionName(String versionName);
     int getVersionProtocol();
     void setVersionProtocol(int protocolVersion);
-    String getFavicon();
-    void setFavicon(String favicon);
+    WrappedServerPing.CompressedImage getFavicon();
+    void setFavicon(WrappedServerPing.CompressedImage favicon);
     boolean isEnforceSecureChat();
     void setEnforceSecureChat(boolean safeChat);
 

--- a/src/main/java/com/comphenix/protocol/wrappers/ping/ServerPingRecord.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/ping/ServerPingRecord.java
@@ -273,13 +273,13 @@ public final class ServerPingRecord implements ServerPingImpl {
     }
 
     @Override
-    public String getFavicon() {
-        return new String(favicon.iconBytes, StandardCharsets.UTF_8);
+    public WrappedServerPing.CompressedImage getFavicon() {
+        return new WrappedServerPing.CompressedImage("data:image/png;base64", favicon.iconBytes);
     }
 
     @Override
-    public void setFavicon(String favicon) {
-        this.favicon.iconBytes = favicon.getBytes(StandardCharsets.UTF_8);
+    public void setFavicon(WrappedServerPing.CompressedImage favicon) {
+        this.favicon.iconBytes = favicon.getDataCopy();
     }
 
     @Override


### PR DESCRIPTION
Fixes setting favicons of server ping. Currently, the image data is encoded to base64 twice resulting in an invalid image sent to the client. This also slightly improves performance as the raw image does not get converted to Base64 in cases that do not require it.

Fixes #2511, #2354