### PR TITLE
Fix possible deadlock in async packet processing

### DIFF
--- a/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
@@ -428,7 +428,7 @@ public class AsyncFilterManager implements AsynchronousManager {
             }
             
             // There are no more listeners - queue the packet for transmission
-            signalFreeProcessingSlot(packet);
+            signalFreeProcessingSlot(packet, onMainThread);
 
             PacketSendingQueue queue = getSendingQueue(packet, false);
             
@@ -467,11 +467,18 @@ public class AsyncFilterManager implements AsynchronousManager {
     }
     
     /**
-     * Signal that a packet has finished processing.
+     * Signal that a packet has finished processing. Tries to process further packets
+     * if a processing slot is still free.
      * @param packet - packet to signal.
+     * @param onMainThread whether or not this method was run by the main thread.
      */
-    public void signalFreeProcessingSlot(PacketEvent packet) {
-        getProcessingQueue(packet).signalProcessingDone();
+    public void signalFreeProcessingSlot(PacketEvent packet, boolean onMainThread) {
+    	PacketProcessingQueue queue = getProcessingQueue(packet);
+    	// mark slot as done
+    	queue.signalProcessingDone();
+    	
+    	// start processing next slot if possible
+    	queue.signalBeginProcessing(onMainThread);
     }
     
     /**


### PR DESCRIPTION
I recently noticed a weird behavior of ProtocolLib when using async packet listeners for chunk packets (in [Orebfuscator](https://github.com/Imprex-Development/orebfuscator)). Sometimes especially on older versions of the game the chunks wouldn't get send to the client.

Being the author of Orebfuscator I tried to fix it but with no success. During my debugging I thankfully found out that the packets never reached the packet listener. Turns out ProtocolLib's processing queue has a hard limit on parallel processing per packet type (SERVER/CLIENT) which isn't necessarily a problem in and of itself. The real problem was that if the server for example sends 100 Packets of type `MAP_CHUNK` (e.g. on player join) and doesn't send more packets of a whitelisted type (added to ListeningWhitelist) then the first 32 ([hard limit in queue](https://github.com/dmulloy2/ProtocolLib/blob/03d7be13d0f5409be9c77c0505a383636a0a1c32/src/main/java/com/comphenix/protocol/async/PacketProcessingQueue.java#L50)) packets will get processed (enqueued into packet listener) and the rest will be stuck until the server tries to send more packets ([`PacketProcessingQueue#L107`](https://github.com/dmulloy2/ProtocolLib/blob/03d7be13d0f5409be9c77c0505a383636a0a1c32/src/main/java/com/comphenix/protocol/async/PacketProcessingQueue.java#L107)). This behavior is similar to a deadlock but not as severe since sending more packets of the whitelisted type will slowing drain the queue 32 packets at a time. (This will only happen if the packet listener increases the processing delay of all packets)

Their are two possible solutions that I found for the problem the first is this PR. Simply starting the processing of the next packet after a packet is done processing should technically solve this. The other solution would be to call [`PacketProcessingQueue::signalBeginProcessing`](https://github.com/dmulloy2/ProtocolLib/blob/03d7be13d0f5409be9c77c0505a383636a0a1c32/src/main/java/com/comphenix/protocol/async/PacketProcessingQueue.java#L126) every tick ([`AsyncFilterManager#L482`](https://github.com/dmulloy2/ProtocolLib/blob/03d7be13d0f5409be9c77c0505a383636a0a1c32/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java#L482)) but I discarded it since the first solution seem to do the job.