### PR TITLE
allow custom Channel type to be wrapped in InjectionFactory#fromChannel

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/InjectionFactory.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/InjectionFactory.java
@@ -168,11 +168,19 @@ public class InjectionFactory {
         Object netManager = this.findNetworkManager(channel);
         Player temporaryPlayer = playerFactory.createTemporaryPlayer(this.server);
 
+        // Use the channel field from an already found network manager to prevent our channel injector given in
+        // this method from overwriting initialized custom channel implementation in some spigot forks
+        Channel wrappedChannel = FuzzyReflection.getFieldValue(netManager, Channel.class, true);
+        if (wrappedChannel == null)  {
+            // Use the channel straight from ChannelHandlerContext as fallback if the field has null value
+            wrappedChannel = channel;
+        }
+
         NettyChannelInjector injector = new NettyChannelInjector(
                 temporaryPlayer,
                 this.server,
                 netManager,
-                channel,
+                wrappedChannel,
                 listener,
                 this,
                 this.errorReporter);


### PR DESCRIPTION
You can create your own custom Channel implementation by extending server socket channel classes that are available in Netty. In Minecraft server there are two transport APIs being used (NIO and Epoll), however extending two different server socket channel classes just to serve only a single purpose usually is not a good solution, as it is not worth effort to maintain two classes at the time.

Fortunately, in the network manager class there's a Channel field. For those plugins/Spigot forks want to do some tinkering with packet sending/receiving through Netty API, they can wrap the original Channel which was gotten from `ChannelHandlerContext` into their own implementation (which is exactly what ProtocolLib is doing).

The worst part is the way how ProtocolLib injects into Netty channel during a server connection initialization and therefore it overwrites the declared custom Channel implementation in the network manager. The main culprit is `InjectionFactory#fromChannel` because it takes the Channel straight from `ChannelHandlerContext` given by `InjectionChannelInboundHandler` as the wrapped channel for the channel injector.

This PR fixes the issue by looking up for existing Channel field inside an already found network manager and if the field has null value, use the Channel from `ChannelHandlerContext` as fallback.