### PR TITLE
add missing abstract methods in SerializedOfflinePlayer

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/SerializedOfflinePlayer.java
+++ b/src/main/java/com/comphenix/protocol/events/SerializedOfflinePlayer.java
@@ -135,6 +135,18 @@ class SerializedOfflinePlayer implements OfflinePlayer, Serializable {
         return bedSpawnLocation;
     }
 
+    @Nullable
+    @Override
+    public Location getRespawnLocation() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Location getLocation() {
+        return null;
+    }
+
     // @Override
     public long getLastLogin() {
         return lastLogin;


### PR DESCRIPTION
Add some missing abstract methods from `OfflinePlayer` that introduced in recent Spigot 1.20.4 API to `SerializedOfflinePlayer` to fix a compile error.

Fixes #2758.
