### PR TITLE
Add AdventureComponentConverter#toJson

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -1,15 +1,15 @@
 /**
  *  ProtocolLib - Bukkit server library that allows access to the Minecraft protocol.
  *  Copyright (C) 2015 dmulloy2
- *
+ * <p>
  *  This program is free software; you can redistribute it and/or modify it under the terms of the
  *  GNU General Public License as published by the Free Software Foundation; either version 2 of
  *  the License, or (at your option) any later version.
- *
+ * <p>
  *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
  *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  *  See the GNU General Public License for more details.
- *
+ * <p>
  *  You should have received a copy of the GNU General Public License along with this program;
  *  if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
  *  02111-1307 USA
@@ -45,6 +45,15 @@ public class AdventureComponentConverter {
      */
     public static WrappedChatComponent fromComponent(Component component) {
             return WrappedChatComponent.fromJson(GsonComponentSerializer.gson().serialize(component));
+    }
+
+    /**
+     * Converts a {@link Component} into a JSON String using {@link GsonComponentSerializer}
+     * @param component Component
+     * @return JSON String
+     */
+    public static String toJson(final Component component) {
+            return GsonComponentSerializer.gson().serialize(component);
     }
 
     public static Class<?> getComponentClass() {


### PR DESCRIPTION
This helps out move the intercepted packet's json to my own relocated Component easily without it being serialized to a WrappedChatComponent, thought this might be useful to others too (You'll still need to use reflections to invoke this method sadly)

if requested i could also commit a one that accepts Object and casts to Component to ease the use of it a little