### PR TITLE
Fixed Listening to Handshake Packets & ServerPingRecord

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/ChannelProtocolUtil.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/ChannelProtocolUtil.java
@@ -12,7 +12,6 @@ import com.comphenix.protocol.reflect.accessors.Accessors;
 import com.comphenix.protocol.reflect.accessors.FieldAccessor;
 import com.comphenix.protocol.reflect.accessors.MethodAccessor;
 import com.comphenix.protocol.reflect.fuzzy.FuzzyFieldContract;
-import com.comphenix.protocol.reflect.fuzzy.FuzzyMethodContract;
 import com.comphenix.protocol.utility.MinecraftReflection;
 
 import io.netty.channel.Channel;
@@ -31,7 +30,7 @@ final class ChannelProtocolUtil {
                 .declaringClassExactType(networkManagerClass)
                 .build());
 
-        BiFunction<Channel, PacketType.Sender, Object> baseResolver = null;
+        BiFunction<Channel, PacketType.Sender, PacketType.Protocol> baseResolver = null;
         if (attributeKeys.isEmpty()) {
         	// since 1.20.5 the protocol is stored as final field in de-/encoder
             baseResolver = new Post1_20_5WrappedResolver();
@@ -75,10 +74,10 @@ final class ChannelProtocolUtil {
         }
 
         // decorate the base resolver by wrapping its return value into our packet type value
-        PROTOCOL_RESOLVER = baseResolver.andThen(nmsProtocol -> PacketType.Protocol.fromVanilla((Enum<?>) nmsProtocol));
+        PROTOCOL_RESOLVER = baseResolver;
     }
 
-    private static final class Pre1_20_2DirectResolver implements BiFunction<Channel, PacketType.Sender, Object> {
+    private static final class Pre1_20_2DirectResolver implements BiFunction<Channel, PacketType.Sender, PacketType.Protocol> {
 
         private final AttributeKey<Object> attributeKey;
 
@@ -87,12 +86,12 @@ final class ChannelProtocolUtil {
         }
 
         @Override
-        public Object apply(Channel channel, PacketType.Sender sender) {
-            return channel.attr(this.attributeKey).get();
+        public PacketType.Protocol apply(Channel channel, PacketType.Sender sender) {
+            return PacketType.Protocol.fromVanilla((Enum<?>) channel.attr(this.attributeKey).get());
         }
     }
 
-    private static final class Post1_20_2WrappedResolver implements BiFunction<Channel, PacketType.Sender, Object> {
+    private static final class Post1_20_2WrappedResolver implements BiFunction<Channel, PacketType.Sender, PacketType.Protocol> {
 
         private final AttributeKey<Object> serverBoundKey;
         private final AttributeKey<Object> clientBoundKey;
@@ -106,7 +105,7 @@ final class ChannelProtocolUtil {
         }
 
         @Override
-        public Object apply(Channel channel, PacketType.Sender sender) {
+        public PacketType.Protocol apply(Channel channel, PacketType.Sender sender) {
             AttributeKey<Object> key = this.getKeyForSender(sender);
             Object codecData = channel.attr(key).get();
             if (codecData == null) {
@@ -114,7 +113,7 @@ final class ChannelProtocolUtil {
             }
 
             FieldAccessor protocolAccessor = this.getProtocolAccessor(codecData.getClass());
-            return protocolAccessor.get(codecData);
+            return PacketType.Protocol.fromVanilla((Enum<?>) protocolAccessor.get(codecData));
         }
 
         private AttributeKey<Object> getKeyForSender(PacketType.Sender sender) {
@@ -141,22 +140,26 @@ final class ChannelProtocolUtil {
     /**
      * Since 1.20.5 the protocol is stored as final field in de-/encoder
      */
-    private static final class Post1_20_5WrappedResolver implements BiFunction<Channel, PacketType.Sender, Object> {
+    private static final class Post1_20_5WrappedResolver implements BiFunction<Channel, PacketType.Sender, PacketType.Protocol> {
 
         // lazy initialized when needed
         private Function<Object, Object> serverProtocolAccessor;
         private Function<Object, Object> clientProtocolAccessor;
 
         @Override
-        public Object apply(Channel channel, PacketType.Sender sender) {
+        public PacketType.Protocol apply(Channel channel, PacketType.Sender sender) {
             String key = this.getKeyForSender(sender);
             Object codecHandler = channel.pipeline().get(key);
             if (codecHandler == null) {
+                String unconfiguratedKey = this.getUnconfiguratedKeyForSender(sender);
+                if (channel.pipeline().get(unconfiguratedKey) != null) {
+                    return PacketType.Protocol.HANDSHAKING;
+                }
                 return null;
             }
 
             Function<Object, Object> protocolAccessor = this.getProtocolAccessor(codecHandler.getClass(), sender);
-            return protocolAccessor.apply(codecHandler);
+            return PacketType.Protocol.fromVanilla((Enum<?>) protocolAccessor.apply(codecHandler));
         }
 
         private Function<Object, Object> getProtocolAccessor(Class<?> codecHandler, PacketType.Sender sender) {
@@ -182,6 +185,17 @@ final class ChannelProtocolUtil {
                     return "encoder";
                 case CLIENT:
                     return "decoder";
+                default:
+                    throw new IllegalArgumentException("Illegal packet sender " + sender.name());
+            }
+        }
+
+        private String getUnconfiguratedKeyForSender(PacketType.Sender sender) {
+            switch (sender) {
+                case SERVER:
+                    return "outbound_config";
+                case CLIENT:
+                    return "inbound_config";
                 default:
                     throw new IllegalArgumentException("Illegal packet sender " + sender.name());
             }

--- a/src/main/java/com/comphenix/protocol/wrappers/ping/ServerPingRecord.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/ping/ServerPingRecord.java
@@ -60,7 +60,7 @@ public final class ServerPingRecord implements ServerPingImpl {
 
                 DATA_WRAPPER = AutoWrapper.wrap(ServerData.class, SERVER_DATA_CLASS);
                 SAMPLE_WRAPPER = AutoWrapper.wrap(PlayerSample.class, PLAYER_SAMPLE_CLASS);
-                FAVICON_WRAPPER = AutoWrapper.wrap(Favicon.class, MinecraftReflection.getMinecraftClass("network.protocol.status.ServerPing$a"));
+                FAVICON_WRAPPER = AutoWrapper.wrap(Favicon.class, MinecraftReflection.getMinecraftClass("network.protocol.status.ServerPing$a", "network.protocol.status.ServerStatus$Favicon"));
 
                 PROFILE_LIST_CONVERTER = BukkitConverters.getListConverter(BukkitConverters.getWrappedGameProfileConverter());
 


### PR DESCRIPTION
On version 1.20.6, `ChannelProtocolUtil` is unable to get the Handshake Protocol PacketType due to Minecraft using a different handler during this phase.

`ServerPingRecord` is also unable to locate the server icon class on Mojang-mapped servers.

Fixes #2647