### PR TITLE
Add Helper methods in AdventureComponentConverter for relocating plugins

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -39,6 +39,15 @@ public class AdventureComponentConverter {
     }
 
     /**
+     * Converts a JSON {@link String} into a Component object
+     * @param json Json String
+     * @return ProtocolLib wrapper
+     */
+    public static Object fromJson(final String json) {
+        return GsonComponentSerializer.gson().deserialize(json);
+    }
+
+    /**
      * Converts a {@link Component} into a ProtocolLib wrapper
      * @param component Component
      * @return ProtocolLib wrapper

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -39,12 +39,30 @@ public class AdventureComponentConverter {
     }
 
     /**
+     * Converts a {@link WrappedChatComponent} into a {@link Component}
+     * @param wrapper ProtocolLib wrapper
+     * @return Component
+     */
+    public static Object fromWrapperAsObject(WrappedChatComponent wrapper) {
+            return fromWrapper(wrapper);
+    }
+
+    /**
+     * Converts a JSON {@link String} into a Component
+     * @param json Json String
+     * @return Component
+     */
+    public static Component fromJson(final String json) {
+            return GsonComponentSerializer.gson().deserialize(json);
+    }
+
+    /**
      * Converts a JSON {@link String} into a Component object
      * @param json Json String
      * @return Component object
      */
-    public static Object fromJson(final String json) {
-        return GsonComponentSerializer.gson().deserialize(json);
+    public static Object fromJsonAsObject(final String json) {
+            return fromJson(json);
     }
 
     /**

--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -41,7 +41,7 @@ public class AdventureComponentConverter {
     /**
      * Converts a JSON {@link String} into a Component object
      * @param json Json String
-     * @return ProtocolLib wrapper
+     * @return Component object
      */
     public static Object fromJson(final String json) {
         return GsonComponentSerializer.gson().deserialize(json);


### PR DESCRIPTION
This helps in using of Adventure while having a shaded + relocated version on your own plugin, Returning Component is a disaster in these cases