### PR TITLE
Fix packet instantiation on 1.20.6

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
@@ -461,7 +461,10 @@ public class PacketRegistry {
 						}
 
 						Object serializer = idCodecEntrySerializerAccessor.invoke(entry);
-						result.classToCodec.put(packetClass, new WrappedStreamCodec(serializer));
+						Field outerThisField = serializer.getClass().getDeclaredField("this$0");
+						outerThisField.setAccessible(true);
+						Object realSer = outerThisField.get(serializer);
+						result.classToCodec.put(packetClass, new WrappedStreamCodec(realSer));
 					}
 
 					// get EnumProtocol and Direction of protocol info


### PR DESCRIPTION
I am using Unsafe, because the packets were not creatable from a null stream.

Other options would be pre-created serialized data that could be read to instantiate the packets or accessing the constructors via reflection and filling in all the parameters.

Probably not mergeable because of the code style but at least it works.