### PR TITLE
Better fix for when packets of type HANDSHAKING are not found in the registry.

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/ChannelProtocolUtil.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/ChannelProtocolUtil.java
@@ -110,7 +110,9 @@ final class ChannelProtocolUtil {
             AttributeKey<Object> key = this.getKeyForSender(sender);
             Object codecData = channel.attr(key).get();
             if (codecData == null) {
-                return null;
+                // If the codec handler was not found, fallback to HANDSHAKING
+                // Fixes https://github.com/dmulloy2/ProtocolLib/issues/2601
+                return PacketType.Protocol.HANDSHAKING;
             }
 
             FieldAccessor protocolAccessor = this.getProtocolAccessor(codecData.getClass());
@@ -152,7 +154,9 @@ final class ChannelProtocolUtil {
             String key = this.getKeyForSender(sender);
             Object codecHandler = channel.pipeline().get(key);
             if (codecHandler == null) {
-                return null;
+                // If the codec handler was not found, fallback to HANDSHAKING
+                // Fixes https://github.com/dmulloy2/ProtocolLib/issues/2601
+                return PacketType.Protocol.HANDSHAKING;
             }
 
             Function<Object, Object> protocolAccessor = this.getProtocolAccessor(codecHandler.getClass(), sender);

--- a/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/manager/NetworkManagerInjector.java
@@ -112,15 +112,7 @@ public class NetworkManagerInjector implements ChannelListener {
         if (marker != null || inboundListeners.contains(packetClass)) {
             // wrap the packet and construct the event
             PacketType.Protocol currentProtocol = injector.getCurrentProtocol(PacketType.Sender.CLIENT);
-            PacketType packetType = PacketRegistry.getPacketType(currentProtocol, packetClass);
-
-            // if packet type could not be found, fallback to HANDSHAKING protocol
-            // temporary workaround for https://github.com/dmulloy2/ProtocolLib/issues/2601
-            if (packetType == null) {
-                packetType = PacketRegistry.getPacketType(PacketType.Protocol.HANDSHAKING, packetClass);
-            }
-
-            PacketContainer container = new PacketContainer(packetType, packet);
+            PacketContainer container = new PacketContainer(PacketRegistry.getPacketType(currentProtocol, packetClass), packet);
             PacketEvent packetEvent = PacketEvent.fromClient(this, container, marker, injector.getPlayer());
 
             // post to all listeners, then return the packet event we constructed


### PR DESCRIPTION
This PR finally fixes the problem that was reported in https://github.com/dmulloy2/ProtocolLib/issues/2601 introduced by commit https://github.com/dmulloy2/ProtocolLib/commit/af33a2ab41199f7c564a5ca9f919e91822532cf4 and replaces the workaround that was previously used.

**Based on this code comment:** https://github.com/dmulloy2/ProtocolLib/blob/b0c4b7fe45024e59505ed132d2df9d61fd5f405d/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java#L208-L210