### PR TITLE
Revert protocol-states being used for 1.8 - 1.20.1 packet class to packet type translation

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/PacketRegistry.java
@@ -712,6 +712,15 @@ public class PacketRegistry {
 			return PacketType.Play.Server.BUNDLE;
 		}
 
+		/*
+		 * Reverts https://github.com/dmulloy2/ProtocolLib/pull/2568 for server versions 1.8 to 1.20.1.
+		 *
+		 * Since packet classes are not shared for these versions,
+		 * the protocol state is not needed to determine the packet type from class.
+		 */
+		if (!MinecraftVersion.CONFIG_PHASE_PROTOCOL_UPDATE.atOrAbove()) {
+			return getPacketType(packet);
+		}
 		Map<Class<?>, PacketType> classToTypesForProtocol = REGISTER.protocolClassToType.get(protocol);
 		return classToTypesForProtocol == null ? null : classToTypesForProtocol.get(packet);
 	}


### PR DESCRIPTION
Fixes #2949, fixes #2909, fixes #2908, fixes #2898, fixes #2886, fixes #2874, fixes #2854, fixes #2775, fixes #2757, fixes #2763, fixes #2741, fixes #2709, fixes #2698, fixes #2658 and closes #2644 by restricting 1.20.2+ specific changes to - surprise - 1.20.2+!
Also closes #2797.
Please merge ASAP @derklaro @dmulloy2.