### PR TITLE
[#2980] Fix dropping of outbound configuration packets if sync processed

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/collection/OutboundPacketListenerSet.java
+++ b/src/main/java/com/comphenix/protocol/injector/collection/OutboundPacketListenerSet.java
@@ -2,12 +2,10 @@ package com.comphenix.protocol.injector.collection;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 
 import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLogger;
 import com.comphenix.protocol.concurrent.PacketTypeListenerSet;
 import com.comphenix.protocol.error.ErrorReporter;
 import com.comphenix.protocol.events.ListenerPriority;

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -320,6 +320,8 @@ public class NettyChannelInjector implements Injector {
                 Object playerConnection = this.getPlayerConnection();
                 if (playerConnection != null) {
                     MinecraftMethods.getSendPacketMethod().invoke(playerConnection, packet);
+                } else {
+                    MinecraftMethods.getNetworkManagerHandleMethod().invoke(this.networkManager, packet);
                 }
             }
         } catch (Exception exception) {


### PR DESCRIPTION
In our current implementation, asnc packet calls are rescheduled to the main thread using the `PlayerConnection::send` method. However, this approach relies on the PlayerConnection being defined, which only occurs after the initial configuration phase is complete. This PR addresses a scenario where the `PlayerConnection` might be `null` during this initial phase. To handle such cases we now invoke the `NetworkManager` directly to skip the `PlayerConnection`.

closes #2980