### PR TITLE
Fix WrappedTeamParameters.Builder incorrectly using displayName for prefix and suffix

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedTeamParameters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedTeamParameters.java
@@ -95,8 +95,8 @@ public class WrappedTeamParameters extends AbstractWrapper {
         private Builder(@Nullable WrappedTeamParameters template) {
             if (template != null) {
                 this.displayName = template.getDisplayName();
-                this.prefix = template.getDisplayName();
-                this.suffix = template.getDisplayName();
+                this.prefix = template.getPrefix();
+                this.suffix = template.getSuffix();
                 this.nametagVisibility = template.getNametagVisibility();
                 this.collisionRule = template.getCollisionRule();
                 this.color = template.getColor();


### PR DESCRIPTION
If you provided a template, it would incorrectly set the prefix and suffix to the template's display name, rather than the prefix and suffix field.