### PR TITLE
Add AdventureComponentConverter#fromComponentObject

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/AdventureComponentConverter.java
@@ -87,6 +87,15 @@ public class AdventureComponentConverter {
     }
 
     /**
+     * Converts an object that is instance of {@link Component} into a ProtocolLib wrapper
+     * @param component Component
+     * @return ProtocolLib wrapper
+     */
+    public static WrappedChatComponent fromComponentObject(Object component) {
+        return fromComponent((Component) component);
+    }
+
+    /**
      * Converts a {@link WrappedComponentStyle} into a {@link Style}
      * @param wrapper ProtocolLib wrapper
      * @return Style


### PR DESCRIPTION
Helps when relocating Adventure on your plugin and still listening to packets containing adventure components