### PR TITLE
Fix ConcurrentModificationException when shutting down async listeners

### DIFF
--- a/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
@@ -17,14 +17,6 @@
 
 package com.comphenix.protocol.async;
 
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
-
 import com.comphenix.protocol.AsynchronousManager;
 import com.comphenix.protocol.PacketStream;
 import com.comphenix.protocol.PacketType;
@@ -37,8 +29,16 @@ import com.comphenix.protocol.injector.collection.InboundPacketListenerSet;
 import com.comphenix.protocol.injector.collection.OutboundPacketListenerSet;
 import com.comphenix.protocol.scheduler.ProtocolScheduler;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Represents a filter manager for asynchronous packets.
@@ -284,9 +284,9 @@ public class AsyncFilterManager implements AsynchronousManager {
     }
     
     private void unregisterAsyncHandlers(PacketProcessingQueue processingQueue, Plugin plugin) {
-        
+
         // Iterate through every packet listener
-        for (AsyncListenerHandler listener : processingQueue.values()) {
+        for (AsyncListenerHandler listener : ImmutableList.copyOf(processingQueue.values())) {
             // Remove the listener
             if (Objects.equal(listener.getPlugin(), plugin)) {
                 unregisterAsyncHandler(listener);


### PR DESCRIPTION
This makes a copy of the list before iterating over it so that ConcurrentModificationException isn't thrown

For example the FastLogin plugin calls `unregisterAsyncHandlers` like this in their onDisabled method
```java
if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
            ProtocolLibrary.getProtocolManager().getAsynchronousManager().unregisterAsyncHandlers(this);
        }
```
which resulted in this error before the fix
```log
[11:02:00 ERROR]: Error occurred while disabling FastLogin v1.12-SNAPSHOT-4dd6b9a
java.util.ConcurrentModificationException: null
        at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1605) ~[?:?]
        at java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1633) ~[?:?]
        at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:52) ~[guava-32.1.2-jre.jar:?]
        at com.google.common.collect.Iterators$ConcatenatedIterator.hasNext(Iterators.java:1400) ~[guava-32.1.2-jre.jar:?]
        at ProtocolLib.jar/com.comphenix.protocol.async.AsyncFilterManager.unregisterAsyncHandlers(AsyncFilterManager.java:289) ~[ProtocolLib.jar:?]
        at ProtocolLib.jar/com.comphenix.protocol.async.AsyncFilterManager.unregisterAsyncHandlers(AsyncFilterManager.java:283) ~[ProtocolLib.jar:?]
        at FastLoginBukkit.jar/com.github.games647.fastlogin.bukkit.FastLoginBukkit.onDisable(FastLoginBukkit.java:198) ~[FastLoginBukkit.jar:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:291) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugin(PaperPluginInstanceManager.java:237) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugins(PaperPluginInstanceManager.java:161) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.disablePlugins(PaperPluginManagerImpl.java:97) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
        at org.bukkit.plugin.SimplePluginManager.disablePlugins(SimplePluginManager.java:541) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.CraftServer.disablePlugins(CraftServer.java:595) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
        at net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:978) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
        at net.minecraft.server.dedicated.DedicatedServer.stopServer(DedicatedServer.java:842) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1273) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[paper-1.20.6.jar:1.20.6-148-20f5165]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```

On thing that bothers me though is the  `: null` part of the exception. Is this the correct fix? I don't know, but it works
¯\\\_(ツ)\_/¯