### PR TITLE
deps: update bytebuddy and shadow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.2'
 }
 
 group = 'com.comphenix.protocol'
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.bytebuddy:byte-buddy:1.14.14'
+    implementation 'net.bytebuddy:byte-buddy:1.15.1'
     compileOnly 'org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT'
     compileOnly 'org.spigotmc:spigot:1.21.1-R0.1-SNAPSHOT'
     compileOnly 'io.netty:netty-all:4.0.23.Final'


### PR DESCRIPTION
The shadow plugin was officially moved to the gradleup organization a while back and the old plugin coordinates will no longer receive updates. See https://github.com/GradleUp/shadow/issues/908 for details.

ByteBuddy need to be updated to the latest version as the old version does not support Java 23. This causes players to not being able to connect to the server as the temporary player instance cannot be generated. Closes #3245 