### PR TITLE
fix/improve publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,4 +181,3 @@ logs/
 build/
 logs/
 .java-version
-gradle.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import io.github.patrick.gradle.remapper.RemapTask
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
     `java-library`
@@ -10,7 +10,6 @@ plugins {
 }
 
 group = "com.comphenix.protocol"
-version = "5.4.0-SNAPSHOT"
 description = "Provides access to the Minecraft protocol"
 
 val mcVersion = "1.21.4"
@@ -69,30 +68,6 @@ dependencies {
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
-
-    withJavadocJar()
-    withSourcesJar()
-}
-
-publishing {
-    publications.withType<MavenPublication> {
-        artifactId = "ProtocolLib"
-    }
-
-    repositories {
-        maven {
-            url = if (isSnapshot) {
-                uri("https://repo.dmulloy2.net/repository/snapshots/")
-            } else {
-                uri("https://repo.dmulloy2.net/repository/releases/")
-            }
-
-            credentials {
-                username = System.getenv("NEXUS_USERNAME")
-                password = System.getenv("NEXUS_PASSWORD")
-            }
-        }
-    }
 }
 
 tasks {
@@ -144,5 +119,85 @@ tasks {
 
     compileJava {
         options.encoding = "UTF-8"
+    }
+
+    register<org.gradle.jvm.tasks.Jar>("javadocJar") {
+        archiveClassifier.set("javadoc")
+        from(getByName("javadoc"))
+    }
+
+    register<org.gradle.jvm.tasks.Jar>("sourcesJar") {
+        archiveClassifier.set("sources")
+        from(project.the<JavaPluginExtension>().sourceSets["main"].allJava)
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+            artifact(tasks.getByName("sourcesJar"))
+            artifact(tasks.getByName("javadocJar"))
+
+            pom {
+                name.set(project.name)
+                description.set(project.description)
+                url.set("https://github.com/dmulloy2/ProtocolLib")
+
+                developers {
+                    developer {
+                        id.set("dmulloy2")
+                        name.set("Dan Mulloy")
+                        url.set("https://dmulloy2.net/")
+                    }
+                    developer {
+                        id.set("aadnk")
+                        email.set("kr_stang@hotmail.com")
+                        name.set("Kristian S. Stangeland")
+                        url.set("https://comphenix.net/")
+                    }
+                }
+
+                licenses {
+                    license {
+                        name.set("GNU GENERAL PUBLIC LICENSE - Version 2, June 1991")
+                        url.set("https://www.gnu.org/licenses/gpl-2.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+
+                scm {
+                    tag.set("HEAD")
+                    url.set("https://github.com/dmulloy2/ProtocolLib")
+                    connection.set("scm:git:git://github.com/dmulloy2/ProtocolLib.git")
+                    developerConnection.set("scm:git:git@github.com:dmulloy2/ProtocolLib.git")
+                }
+
+                issueManagement {
+                    system.set("GitHub Issues")
+                    url.set("https://github.com/dmulloy2/ProtocolLib/issues")
+                }
+
+                ciManagement {
+                    system.set("Jenkins")
+                    url.set("https://ci.dmulloy2.net/job/ProtocolLib")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            url = if (isSnapshot) {
+                uri("https://repo.dmulloy2.net/repository/snapshots/")
+            } else {
+                uri("https://repo.dmulloy2.net/repository/releases/")
+            }
+
+            credentials {
+                username = System.getenv("NEXUS_USERNAME")
+                password = System.getenv("NEXUS_PASSWORD")
+            }
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=5.4.0-SNAPSHOT


### PR DESCRIPTION
Publishing is currently not fully configured, causing e.g. jitpack to fail building the latest snapshots from source [because there is no maven publication registered]. The version was moved to gradle.properties, allowing to set the current project version via `-Pversion=<version>` in command line. The publishing configuration was moved under the tasks configuration so that gradle configures the tasks before configuring the publications.

Worked locally to publish to maven local, obviously cannot tell if release publish still works.