### PR TITLE
Preserve the pipeline order when async receiving packets

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -271,7 +271,7 @@ public class NettyChannelInjector implements Injector {
         }
 
         try {
-            this.channel.pipeline().context(WIRE_PACKET_ENCODER_NAME).writeAndFlush(packet);
+            this.listenerInvoker.send(packet);
         } catch (Exception exception) {
             this.errorReporter.reportWarning(this, Report.newBuilder(REPORT_CANNOT_SEND_PACKET)
                     .messageParam(packet, this.playerName)

--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -271,7 +271,7 @@ public class NettyChannelInjector implements Injector {
         }
 
         try {
-            this.listenerInvoker.send(packet);
+            this.channel.pipeline().context(WIRE_PACKET_ENCODER_NAME).writeAndFlush(packet);
         } catch (Exception exception) {
             this.errorReporter.reportWarning(this, Report.newBuilder(REPORT_CANNOT_SEND_PACKET)
                     .messageParam(packet, this.playerName)
@@ -289,8 +289,7 @@ public class NettyChannelInjector implements Injector {
         
         this.ensureInEventLoop(() -> {
             try {
-                // try to invoke the method, this should normally not fail
-                this.listenerInvoker.read(packet);
+                this.channel.pipeline().context(INBOUND_INTERCEPTOR_NAME).fireChannelRead(packet);
             } catch (Exception exception) {
                 this.errorReporter.reportWarning(this, Report.newBuilder(REPORT_CANNOT_READ_PACKET)
                         .messageParam(packet, this.playerName)


### PR DESCRIPTION
This fixes one of the oldest open issues in Floodgate GeyserMC/Floodgate#143.
ProtocolLib their async packet handlers currently don't respect the pipeline order and instead always let the Minecraft Connection class handle everything.

The Floodgate issue describes the following scenario:
A packet handler is created for `PacketType.Login.Client.START`, and when it comes time to handle that packet the async handler cancels the packet and keeps a copy for later use. If the packet is not async then `ctx#fireChannelRead` is executed. When the plugin is done handling that packet `readServerboundPacket` sends it to the Connection class without considering that there might be other channel handlers between ProtocolLib and Minecraft's `packet_handler`.

This PR calls `ctx#fireChannelRead`, fixing the order that was broken.