### PR TITLE
fix: Show helpful message when no supported updater loads

### DIFF
--- a/src/main/java/com/comphenix/protocol/ProtocolLib.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLib.java
@@ -504,6 +504,17 @@ public class ProtocolLib extends JavaPlugin {
     }
 
     private void checkUpdates() {
+        // Do not run updater if no supported updater is loaded
+        if (this.updater == null) {
+            highlyVisibleError(
+                    " WARNING ",
+                    " ProtocolLib is unable to check for updates. ",
+                    " You are likely not using a supported version (Such as CraftBukkit). "
+            );
+            ProtocolLibrary.disableUpdates();
+            return;
+        }
+
         // Ignore milliseconds - it's pointless
         long currentTime = System.currentTimeMillis() / MILLI_PER_SECOND;
 


### PR DESCRIPTION
Fixes https://github.com/dmulloy2/ProtocolLib/issues/3282

Currently ProtocolLib sends the following when loading on a server which does not implement the spigot config.

Alternative messaging could be that there is no supported updater, this would remain more consistent with other branding indicating CraftBukkit is supported.

`
[22:13:24] [Server thread/ERROR]:   [ProtocolLib] INTERNAL ERROR: Cannot perform automatic updates.
  If this problem hasn't already been reported, please open a ticket
  at https://github.com/dmulloy2/ProtocolLib/issues with the following data:
  Stack Trace:
  java.lang.NullPointerException: Cannot invoke "com.comphenix.protocol.updater.Updater.isChecking()" because "this.updater" is null
        at com.comphenix.protocol.ProtocolLib.checkUpdates(ProtocolLib.java:514)
        at com.comphenix.protocol.ProtocolLib.lambda$createPacketTask$0(ProtocolLib.java:485)
        at org.bukkit.craftbukkit.v1_21_R1.scheduler.CraftTask.run(CraftTask.java:77)
        at org.bukkit.craftbukkit.v1_21_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:414)
        at net.minecraft.server.MinecraftServer.c(MinecraftServer.java:1388)
        at net.minecraft.server.dedicated.DedicatedServer.c(DedicatedServer.java:393)
        at net.minecraft.server.MinecraftServer.a(MinecraftServer.java:1290)
        at net.minecraft.server.MinecraftServer.y(MinecraftServer.java:1040)
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:310)
        at java.base/java.lang.Thread.run(Thread.java:1583)
  Dump:
    manager:
      com.comphenix.protocol.injector.PacketFilterManager@62afb16b[
        plugin=ProtocolLib v5.3.0-SNAPSHOT-732
        server=CraftServer{serverName=Pebble,serverVersion=git-Bukkit-19bf846,minecraftVersion=1.21.1}
        reporter=com.comphenix.protocol.ProtocolLib$1@299584bc
        minecraftVersion=(MC: 1.21.1)
        asyncFilterManager=com.comphenix.protocol.async.AsyncFilterManager@392ce8e6
        pluginVerifier=com.comphenix.protocol.injector.PluginVerifier@26972241
        mainThreadPacketTypes=com.comphenix.protocol.concurrent.PacketTypeListenerSet@7c94b48d
        inboundListeners=com.comphenix.protocol.injector.collection.InboundPacketListenerSet@79217fc7
        outboundListeners=com.comphenix.protocol.injector.collection.OutboundPacketListenerSet@2714d3dd
        registeredListeners=[PacketAdapter[plugin=DeluxeCombat, sending=ListeningWhitelist[priority=NORMAL, packets=[WORLD_PARTICLES[class=PacketPlayOutWorldParticles, id=41]], gamephase=PLAYING, options=[]], receiving=EMPTY_WHITELIST], PacketAdapter[plugin=DeluxeCombat, sending=ListeningWhitelist[priority=NORMAL, packets=[ENTITY_VELOCITY[class=PacketPlayOutEntityVelocity, id=90]], gamephase=PLAYING, options=[]], receiving=EMPTY_WHITELIST], PacketAdapter[plugin=Citizens, sending=ListeningWhitelist[priority=HIGHEST, packets=[ENTITY_METADATA[class=PacketPlayOutEntityMetadata, id=88]], gamephase=PLAYING, options=[]], receiving=EMPTY_WHITELIST], PacketAdapter[plugin=DeluxeCombat, sending=ListeningWhitelist[priority=NORMAL, packets=[NAMED_SOUND_EFFECT[class=PacketPlayOutNamedSoundEffect, id=104]], gamephase=PLAYING, options=[]], receiving=EMPTY_WHITELIST], PacketAdapter[plugin=WorldGuardExtraFlags, sending=ListeningWhitelist[priority=NORMAL, packets=[REMOVE_ENTITY_EFFECT[class=PacketPlayOutRemoveEntityEffect, id=67]], gamephase=PLAYING, options=[]], receiving=EMPTY_WHITELIST], PacketAdapter[plugin=Skyblock, sending=ListeningWhitelist[priority=NORMAL, packets=[SPAWN_ENTITY[class=PacketPlayOutSpawnEntity, id=1]], gamephase=PLAYING, options=[]], receiving=EMPTY_WHITELIST], PacketAdapter[plugin=Citizens, sending=ListeningWhitelist[priority=HIGHEST, packets=[PLAYER_INFO[class=ClientboundPlayerInfoUpdatePacket, id=62]], gamephase=PLAYING, options=[ASYNC]], receiving=EMPTY_WHITELIST], PacketAdapter[plugin=Citizens, sending=ListeningWhitelist[priority=HIGHEST, packets=[ENTITY_HEAD_ROTATION[class=PacketPlayOutEntityHeadRotation, id=72], REL_ENTITY_MOVE_LOOK[class=PacketPlayOutRelEntityMoveLook, id=47], ENTITY_LOOK[class=PacketPlayOutEntityLook, id=48], ENTITY_TELEPORT[class=PacketPlayOutEntityTeleport, id=112]], gamephase=PLAYING, options=[ASYNC]], receiving=EMPTY_WHITELIST]]
        networkManagerInjector=com.comphenix.protocol.injector.netty.manager.NetworkManagerInjector@388e6854
        debug=false
        closed=false
        injected=true
      ]
  Sender:
    com.comphenix.protocol.ProtocolLib@13ca17a8[
      statistics=com.comphenix.protocol.metrics.Statistics@1241a437
      packetTask=com.comphenix.protocol.scheduler.DefaultTask@5946a2e3
      tickCounter=20
      configExpectedMod=1
      updater=<null>
      redirectHandler=com.comphenix.protocol.ProtocolLib$2@4e4f5ec
      scheduler=com.comphenix.protocol.scheduler.DefaultScheduler@47d0d58f
      commandProtocol=com.comphenix.protocol.CommandProtocol@58afa15e
      commandPacket=com.comphenix.protocol.CommandPacket@34124112
      commandFilter=com.comphenix.protocol.CommandFilter@177a89e9
      packetLogging=com.comphenix.protocol.PacketLogging@56c74a24
      skipDisable=false
      isEnabled=true
      loader=org.bukkit.plugin.java.JavaPluginLoader@7347b4f3
      server=CraftServer{serverName=Pebble,serverVersion=git-Bukkit-19bf846,minecraftVersion=1.21.1}
      file=plugins/ProtocolLib.jar
      description=org.bukkit.plugin.PluginDescriptionFile@557b7158
      dataFolder=plugins/ProtocolLib
      classLoader=org.bukkit.plugin.java.PluginClassLoader@4b6eca77
      naggable=true
      newConfig=YamlConfiguration[path='', root='YamlConfiguration']
      configFile=plugins/ProtocolLib/config.yml
      logger=org.bukkit.plugin.PluginLogger@7af77150
    ]
  Version:
    ProtocolLib v5.3.0-SNAPSHOT-732
  Java Version:
    21.0.2
  Server:
    git-Bukkit-19bf846 (MC: 1.21.1)
`