### PR TITLE
update dependencies for java 24 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 plugins {
     `java-library`
     `maven-publish`
-    id("com.gradleup.shadow") version "8.3.2"
-    id("io.github.patrick.remapper") version "1.4.1"
+    id("com.gradleup.shadow") version "9.0.0-beta13"
+    id("io.github.patrick.remapper") version "1.4.2"
 }
 
 group = "com.comphenix.protocol"
@@ -47,7 +47,7 @@ repositories {
 }
 
 dependencies {
-    implementation("net.bytebuddy:byte-buddy:1.15.1")
+    implementation("net.bytebuddy:byte-buddy:1.17.5")
     compileOnly("org.spigotmc:spigot-api:${mcVersion}-R0.1-SNAPSHOT")
     compileOnly("org.spigotmc:spigot:${mcVersion}-R0.1-SNAPSHOT:remapped-mojang")
     compileOnly("io.netty:netty-all:4.0.23.Final")


### PR DESCRIPTION
ByteBuddy update was required for Java 24 support. This consequently forced a shadow update as ByteBuddy bundles java 24 specific files (multi release jar), which weren't yet supported by the bundled asm version in the old shadow version.

Closes #3382