### PR TITLE
fix: initialization error for WrappedChatComponent on 1.20.4-1.21.5

### DIFF
--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -685,8 +685,8 @@ public final class MinecraftReflection {
      * @throws IllegalStateException If the class could not be found or deduced.
      */
     public static Class<?> getChatSerializerClass() {
-        return getMinecraftClass("network.chat.ComponentSerialization",
-                "network.chat.IChatBaseComponent$ChatSerializer", "network.chat.Component$Serializer", "IChatBaseComponent$ChatSerializer");
+        return getMinecraftClass("network.chat.IChatBaseComponent$ChatSerializer",
+                "network.chat.Component$Serializer", "network.chat.ComponentSerialization", "IChatBaseComponent$ChatSerializer");
     }
 
     /**


### PR DESCRIPTION
The ComponentSerialization class also exists on these versions, so the MinecraftReflection#getChatSerializerClass method would return a class that does not contain the expected methods, hence failing initialization.
This commit changes the lookup order, so that the subclasses are searched before the ComponentSerialization class.

Closes #3478
Closes #3482
Closes #3488