### PR TITLE
fix: incorrect version gating on WrappedTeamParamters

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedTeamParameters.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedTeamParameters.java
@@ -202,7 +202,7 @@ public class WrappedTeamParameters extends AbstractWrapper {
             wrapped.writeComponent(1, prefix);
             wrapped.writeComponent(2, suffix);
 
-            if (MinecraftVersion.v1_20_5.atOrAbove()) {
+            if (MinecraftVersion.v1_21_5.atOrAbove()) {
                 wrapped.visiblityModifier.writeSafely(0, nametagVisibility);
                 wrapped.collisionRuleModifier.writeSafely(0, collisionRule);
             } else {


### PR DESCRIPTION
This was incorrectly gated as 1.20.5 instead of 1.21.5, leading to the values of nametag visibility and collision rules being ignored on MC versions 1.20.5-1.21.4.