### PR TITLE
Added support for Minecraft 1.21.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 group = "com.comphenix.protocol"
 description = "Provides access to the Minecraft protocol"
 
-val mcVersion = "1.21.6"
+val mcVersion = "1.21.7"
 val isSnapshot = version.toString().endsWith("-SNAPSHOT")
 val buildNumber = System.getenv("BUILD_NUMBER") ?: ""
 val isJenkins = buildNumber.isNotEmpty()

--- a/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
@@ -35,12 +35,12 @@ public class ProtocolLibrary {
     /**
      * The maximum version ProtocolLib has been tested with.
      */
-    public static final String MAXIMUM_MINECRAFT_VERSION = "1.21.5";
+    public static final String MAXIMUM_MINECRAFT_VERSION = "1.21.8";
 
     /**
-     * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.21.5) was released.
+     * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.21.8) was released.
      */
-    public static final String MINECRAFT_LAST_RELEASE_DATE = "2025-03-25";
+    public static final String MINECRAFT_LAST_RELEASE_DATE = "2025-07-17";
 
     private static Plugin plugin;
     private static ProtocolConfig config;

--- a/src/main/java/com/comphenix/protocol/injector/packet/internal/ProtocolInfoWrapper.java
+++ b/src/main/java/com/comphenix/protocol/injector/packet/internal/ProtocolInfoWrapper.java
@@ -31,6 +31,7 @@ public class ProtocolInfoWrapper extends AbstractWrapper {
     static {
         SIMPLE_UNBOUND_PROTOCOL_CLASS = MinecraftReflection.getMinecraftClass(
                 "network.protocol.SimpleUnboundProtocol" /* 1.21.5+ */,
+                "network.protocol.UnboundProtocol" /* 1.21.8+ Alternative */,
                 "network.ProtocolInfo$a" /* Spigot Mappings */,
                 "network.ProtocolInfo$Unbound" /* Mojang Mappings */);
         BIND_SIMPLE_ACCESSOR = Accessors.getMethodAccessor(FuzzyReflection.fromClass(SIMPLE_UNBOUND_PROTOCOL_CLASS)

--- a/src/main/java/com/comphenix/protocol/utility/MinecraftProtocolVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftProtocolVersion.java
@@ -94,6 +94,8 @@ public final class MinecraftProtocolVersion {
 
         map.put(new MinecraftVersion(1, 21, 0), 767);
         map.put(new MinecraftVersion(1, 21, 2), 768);
+        map.put(new MinecraftVersion(1, 21, 6), 771);
+        map.put(new MinecraftVersion(1, 21, 8), 772);
         return map;
     }
 


### PR DESCRIPTION
# Summary
This PR updates ProtocolLib to support Minecraft 1.21.8 compatibility. The changes address the runtime error where ProtocolLib fails to load due to missing class mappings for newer Minecraft versions.

## Changes Made

### Version Updates
- Updated build system to target Minecraft 1.21.7 (md_5: 1.21.8 is released. This is a client only release and the server is identical to 1.21.7 (other than version number).
- Updated `MAXIMUM_MINECRAFT_VERSION` from "1.21.5" to "1.21.8" in `ProtocolLibrary.java`
- Updated `MINECRAFT_LAST_RELEASE_DATE` to reflect the latest release

### Protocol Version Mappings
- Added protocol version mapping for Minecraft 1.21.6 → Protocol 771
- Added protocol version mapping for Minecraft 1.21.8 → Protocol 772

### Class Mapping Fixes
- Updated `ProtocolInfoWrapper.java` to handle class structure changes in newer Minecraft versions
- Added fallback class names for `SimpleUnboundProtocol` and `UnboundProtocol` classes
- Improved compatibility with both Spigot and Mojang mappings