### PR TITLE
Use the correct reflection method in setTypeAndData method, and rename GET_BLOCK_DATA to DEFAULT_BLOCK_DATA for clarity

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/WrappedBlockData.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/WrappedBlockData.java
@@ -45,7 +45,7 @@ public abstract class WrappedBlockData extends AbstractWrapper implements Clonab
         private static MethodAccessor TO_LEGACY_DATA;
         private static MethodAccessor GET_BLOCK;
         private static MethodAccessor BLOCK_FROM_MATERIAL;
-        private static MethodAccessor GET_BLOCK_DATA;
+        private static MethodAccessor DEFAULT_BLOCK_DATA;
         private static MethodAccessor FROM_LEGACY_DATA;
         private static MethodAccessor GET_HANDLE;
 
@@ -100,7 +100,7 @@ public abstract class WrappedBlockData extends AbstractWrapper implements Clonab
                         .parameterCount(0)
                         .returnTypeExact(IBLOCK_DATA)
                         .build();
-                GET_BLOCK_DATA = Accessors.getMethodAccessor(fuzzy.getMethod(contract));
+                DEFAULT_BLOCK_DATA = Accessors.getMethodAccessor(fuzzy.getMethod(contract));
 
                 fuzzy = FuzzyReflection.fromClass(MinecraftReflection.getCraftBukkitClass("block.data.CraftBlockData"));
                 contract = FuzzyMethodContract
@@ -131,7 +131,7 @@ public abstract class WrappedBlockData extends AbstractWrapper implements Clonab
         @Override
         public void setType(Material material) {
             Object block = BLOCK_FROM_MATERIAL.invoke(null, material);
-            setHandle(GET_BLOCK_DATA.invoke(block));
+            setHandle(DEFAULT_BLOCK_DATA.invoke(block));
         }
 
         @Override
@@ -151,7 +151,7 @@ public abstract class WrappedBlockData extends AbstractWrapper implements Clonab
 
         private static WrappedBlockData createNewData(Material material) {
             Object block = BLOCK_FROM_MATERIAL.invoke(null, material);
-            return new NewBlockData(GET_BLOCK_DATA.invoke(block));
+            return new NewBlockData(DEFAULT_BLOCK_DATA.invoke(block));
         }
 
         private static WrappedBlockData createNewData(Material material, int data) {


### PR DESCRIPTION
Use the correct reflection method in setTypeAndData method, and rename GET_BLOCK_DATA to DEFAULT_BLOCK_DATA for clarity.

Fixes https://github.com/dmulloy2/ProtocolLib/issues/3509 (See there for more info)
