### PR TITLE
ResourceLocation was renamed in 1.21.11

### DIFF
--- a/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
+++ b/src/main/java/com/comphenix/protocol/utility/MinecraftReflection.java
@@ -921,7 +921,7 @@ public final class MinecraftReflection {
     }
 
     public static Class<?> getMinecraftKeyClass() {
-        return getMinecraftClass("resources.MinecraftKey", "resources.ResourceLocation", "MinecraftKey");
+        return getMinecraftClass("resources.MinecraftKey", "resources.ResourceLocation", "resources.Identifier", "MinecraftKey");
     }
 
     public static Class<?> getMobEffectListClass() {


### PR DESCRIPTION
Fixes errors like 
```Exception java.lang.RuntimeException: Unable to find resources.MinecraftKey (resources.ResourceLocation, MinecraftKey)```
in 1.21.11