### PR TITLE
Mark 1.21.11 as supported

### DIFF
--- a/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLibrary.java
@@ -35,12 +35,12 @@ public class ProtocolLibrary {
     /**
      * The maximum version ProtocolLib has been tested with.
      */
-    public static final String MAXIMUM_MINECRAFT_VERSION = "1.21.8";
+    public static final String MAXIMUM_MINECRAFT_VERSION = "1.21.11";
 
     /**
-     * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.21.8) was released.
+     * The date (with ISO 8601 or YYYY-MM-DD) when the most recent version (1.21.11) was released.
      */
-    public static final String MINECRAFT_LAST_RELEASE_DATE = "2025-07-17";
+    public static final String MINECRAFT_LAST_RELEASE_DATE = "2025-12-09";
 
     private static Plugin plugin;
     private static ProtocolConfig config;


### PR DESCRIPTION
1.21.11 support was added in December, but the `MAXIMUM_MINECRAFT_VERSION` constant wasn't updated, causing a console nag when running on >1.21.8.