### PR TITLE
Fix Injector.getPlayer() using TemporaryPlayer when a Bukkit player is available

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -29,6 +29,7 @@ import com.comphenix.protocol.injector.NetworkProcessor;
 import com.comphenix.protocol.injector.netty.Injector;
 import com.comphenix.protocol.injector.netty.WirePacket;
 import com.comphenix.protocol.injector.packet.PacketRegistry;
+import com.comphenix.protocol.injector.temporary.TemporaryPlayer;
 import com.comphenix.protocol.reflect.FuzzyReflection;
 import com.comphenix.protocol.reflect.accessors.Accessors;
 import com.comphenix.protocol.reflect.accessors.FieldAccessor;
@@ -343,7 +344,7 @@ public class NettyChannelInjector implements Injector {
     @Override
     public Player getPlayer() {
         // if the player was already resolved there is no need to do further lookups
-        if (this.player != null) {
+        if (this.player != null && !(this.player instanceof TemporaryPlayer)) {
             return this.player;
         }
 


### PR DESCRIPTION
On my server I had a lot of issues where I was getting a temporary player for packets sent before PlayerJoinEvent, even tho Bukkit.getPlayerExact was returning the actual joined player

So I did some digging and I found out that even tho it returned the temporary player, `playerName` variable was set, and with more digging it turns out that even if a bukkit player is available, doing getPlayer on the injector would never check for Bukkit player if a temporary player was already assigned

so I decided to fix it myself, this is how I did it, and I figured I should make a PR for it, so others wont have this issue