### PR TITLE
Fix 26.1.2 problem with invalid constructor selection

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/StructureCache.java
+++ b/src/main/java/com/comphenix/protocol/injector/StructureCache.java
@@ -287,8 +287,8 @@ public class StructureCache {
 
         if (registryByteBuf.isPresent()) {
             ConstructorAccessor accessor = Accessors.getConstructorAccessor(FuzzyReflection.fromClass(serializerBase, true).getConstructor(FuzzyMethodContract.newBuilder()
-                    .parameterDerivedOf(ByteBuf.class)
-                    .parameterDerivedOf(MinecraftReflection.getRegistryAccessClass())
+                    .parameterExactType(ByteBuf.class)
+                    .parameterExactType(MinecraftReflection.getRegistryAccessClass())
                     .build()));
             TRICKED_DATA_SERIALIZER_BASE = (buf) -> accessor.invoke(buf, MinecraftRegistryAccess.get());
         } else {


### PR DESCRIPTION
Fixes packet creation on newer versions

[15:33:02 WARN]: java.lang.IllegalArgumentException: Cannot create instance of class net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket
[15:33:02 WARN]: 	at ProtocolLib.jar//com.comphenix.protocol.injector.StructureCache.newInstance(StructureCache.java:95)
[15:33:02 WARN]: 	at ProtocolLib.jar//com.comphenix.protocol.injector.StructureCache.newPacket(StructureCache.java:82)
[15:33:02 WARN]: 	at ProtocolLib.jar//com.comphenix.protocol.injector.StructureCache.newPacket(StructureCache.java:217)
[15:33:02 WARN]: 	at ProtocolLib.jar//com.comphenix.protocol.events.PacketContainer.<init>(PacketContainer.java:120)
[15:33:02 WARN]: 	at Intave.jar//de.jpx3.intave.packet.reader.ReaderTests.testAllPlayerInfoReaders(ReaderTests.java:33)
[15:33:02 WARN]: 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
[15:33:02 WARN]: 	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
[15:33:02 WARN]: 	at Intave.jar//de.jpx3.intave.test.Tester.runTest(Tester.java:86)
[15:33:02 WARN]: 	at Intave.jar//de.jpx3.intave.test.Tester.runTests(Tester.java:52)
[15:33:02 WARN]: 	at Intave.jar//de.jpx3.intave.test.Tester.run(Tester.java:25)
[15:33:02 WARN]: 	at Intave.jar//de.jpx3.intave.test.TestService.performTest(TestService.java:269)
[15:33:02 WARN]: 	at Intave.jar//de.jpx3.intave.test.TestService.performTests(TestService.java:187)
[15:33:02 WARN]: 	at Intave.jar//de.jpx3.intave.executor.Synchronizer.lambda$wrapped$0(Synchronizer.java:46)
[15:33:02 WARN]: 	at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78)
[15:33:02 WARN]: 	at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474)
[15:33:02 WARN]: 	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1802)
[15:33:02 WARN]: 	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1655)
[15:33:02 WARN]: 	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:449)
[15:33:02 WARN]: 	at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1713)
[15:33:02 WARN]: 	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1383)
[15:33:02 WARN]: 	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:304)
[15:33:02 WARN]: 	at java.base/java.lang.Thread.run(Thread.java:1474)
