### PR TITLE
fix: NettyChannelInjector.getPlayer() overwrites TemporaryPlayer with null

### DIFF
--- a/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/channel/NettyChannelInjector.java
@@ -350,8 +350,9 @@ public class NettyChannelInjector implements Injector {
 
         // check if the name of the player is already known to the injector
         if (this.playerName != null) {
-            this.player = Bukkit.getPlayerExact(this.playerName);
-            if (this.player != null) {
+            Player bukkitPlayer = Bukkit.getPlayerExact(this.playerName);
+            if (bukkitPlayer != null) {
+                this.player = bukkitPlayer;
                 this.injectionFactory.cacheInjector(this.player, this);
             }
         }


### PR DESCRIPTION
Bukkit.getPlayerExact() returns null during login phase. Assigning its return value directly to this.player destroys the TemporaryPlayer instance, causing subsequent getPlayer() calls to return null. Use a local variable to only replace the player on success