### PR TITLE
fix: only sign non snapshots and non jitpack versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ description = "Provides access to the Minecraft protocol"
 
 val mcVersion = "26.1"
 val isSnapshot = version.toString().endsWith("-SNAPSHOT")
+val isJitPack = System.getenv("JITPACK")?.equals("true", ignoreCase = true) ?: false
 val commitHash = System.getenv("COMMIT_SHA") ?: ""
 val isCI = commitHash.isNotEmpty()
 
@@ -124,7 +125,7 @@ tasks {
 
 mavenPublishing {
     publishToMavenCentral()
-    if (!isSnapshot) {
+    if (!isSnapshot && !isJitPack) {
         signAllPublications()
     }
 


### PR DESCRIPTION
Did not realize jitpack overrides the version thus the snapshot check wont work. This works with

`./gradlew clean -Pgroup=com.github.dmulloy2 -Pversion=-b0b9b666a7-1 -xtest assemble publishToMavenLocal` (what jitpack executed)