### PR TITLE
fix: explicitly declare parameters of ServerPingRecord constructor

### DIFF
--- a/src/main/java/com/comphenix/protocol/wrappers/ping/ServerPingRecord.java
+++ b/src/main/java/com/comphenix/protocol/wrappers/ping/ServerPingRecord.java
@@ -59,7 +59,7 @@ public final class ServerPingRecord implements ServerPingImpl {
                 PLAYER_SAMPLE_CLASS = MinecraftReflection.getServerPingPlayerSampleClass();
                 SERVER_DATA_CLASS = MinecraftReflection.getServerPingServerDataClass();
 
-                PING_CTOR = Accessors.getConstructorAccessor(SERVER_PING.getConstructors()[0]);
+                PING_CTOR = Accessors.getConstructorAccessor(SERVER_PING, MinecraftReflection.getIChatBaseComponentClass(), Optional.class, Optional.class, Optional.class, boolean.class);
 
                 DATA_WRAPPER = AutoWrapper.wrap(ServerData.class, SERVER_DATA_CLASS);
                 SAMPLE_WRAPPER = AutoWrapper.wrap(PlayerSample.class, PLAYER_SAMPLE_CLASS);


### PR DESCRIPTION
Some Spigot forks (e.g., Leaf) add additional constructors with different parameters, which causes the previous naive implementation of getting the first available constructor to fail.

See https://github.com/tritonmc/Triton/issues/612