### PR TITLE
fix: select player info data list field

### DIFF
--- a/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
+++ b/src/main/java/com/comphenix/protocol/events/AbstractStructure.java
@@ -598,9 +598,7 @@ public abstract class AbstractStructure {
      */
     public StructureModifier<List<PlayerInfoData>> getPlayerInfoDataLists() {
         // Convert to and from the ProtocolLib wrapper
-        return structureModifier.withType(
-                Collection.class,
-                BukkitConverters.getListConverter(PlayerInfoData.getConverter()));
+        return getLists(PlayerInfoData.getConverter());
     }
 
     /**

--- a/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
+++ b/src/test/java/com/comphenix/protocol/events/PacketContainerTest.java
@@ -848,14 +848,14 @@ public class PacketContainerTest {
                 new WrappedGameProfile(new UUID(0, 0), "system"),
                 null,
                 (WrappedRemoteChatSessionData) null);
-        updatePlayerInfoActions.getPlayerInfoDataLists().write(1, Collections.singletonList(data));
+        StructureModifier<List<PlayerInfoData>> playerInfoDataLists = updatePlayerInfoActions.getPlayerInfoDataLists();
+        Assertions.assertEquals(1, playerInfoDataLists.size());
+        playerInfoDataLists.write(0, Collections.singletonList(data));
 
         Set<EnumWrappers.PlayerInfoAction> readActions = updatePlayerInfoActions.getPlayerInfoActions().read(0);
-        Assertions.assertTrue(readActions.contains(EnumWrappers.PlayerInfoAction.ADD_PLAYER));
-        Assertions.assertTrue(readActions.contains(EnumWrappers.PlayerInfoAction.UPDATE_LATENCY));
-        Assertions.assertTrue(readActions.contains(EnumWrappers.PlayerInfoAction.UPDATE_LISTED));
+        Assertions.assertEquals(actions, readActions);
 
-        Collection<PlayerInfoData> readData = updatePlayerInfoActions.getPlayerInfoDataLists().read(1);
+        Collection<PlayerInfoData> readData = playerInfoDataLists.read(0);
         Assertions.assertEquals(1, readData.size());
 
         PlayerInfoData firstData = readData.iterator().next();


### PR DESCRIPTION
Fixed `getPlayerInfoDataLists()` incorrectly including the player info actions field.

`ClientboundPlayerInfoUpdatePacket` contains an `EnumSet<Action>` for its actions and a `List<Entry>` for its player info entries. Since `getPlayerInfoDataLists()` searched for every `Collection` field, both fields were included in the returned modifier.

This made index `0` point to the actions field instead of the entries list. Writing `PlayerInfoData` to the expected index could then fail with:

```text
ClassCastException: Cannot cast java.util.ArrayList to java.util.EnumSet
```
Plugins had to use the undocumented index 1 as a workaround.

The method now uses the existing getLists() helper, so only actual List fields are selected and the player info entries are available at index 0 as expected.

Validated with ./gradlew.bat clean test assemble.

Fixes #2760
Related: #3215, #3361, #3303