### PR TITLE
perf: avoid per-call lambda allocation in CachedPackage#getPackageClass

### DIFF
--- a/src/main/java/com/comphenix/protocol/utility/CachedPackage.java
+++ b/src/main/java/com/comphenix/protocol/utility/CachedPackage.java
@@ -88,10 +88,6 @@ final class CachedPackage {
      * @throws RuntimeException If we are unable to find the given class.
      */
     public Optional<Class<?>> getPackageClass(String className, String... aliases) {
-        // Fast path: a plain get on cache hit. computeIfAbsent(className, x -> {...}) allocated a
-        // fresh capturing lambda (capturing className + aliases) on EVERY call — even hits — which,
-        // on the per-packet isBundlePacket() path, was a large source of allocation. The negative
-        // result (class absent on this version) is cached too, so this stays a single get afterwards.
         Optional<Class<?>> cached = cache.get(className);
         if (cached != null) {
             return cached;

--- a/src/main/java/com/comphenix/protocol/utility/CachedPackage.java
+++ b/src/main/java/com/comphenix/protocol/utility/CachedPackage.java
@@ -88,20 +88,27 @@ final class CachedPackage {
      * @throws RuntimeException If we are unable to find the given class.
      */
     public Optional<Class<?>> getPackageClass(String className, String... aliases) {
-        return cache.computeIfAbsent(className, x -> {
-            Optional<Class<?>> clazz = resolveClass(className);
-            if (clazz.isPresent()) {
-                return clazz;
-            }
+        // Fast path: a plain get on cache hit. computeIfAbsent(className, x -> {...}) allocated a
+        // fresh capturing lambda (capturing className + aliases) on EVERY call — even hits — which,
+        // on the per-packet isBundlePacket() path, was a large source of allocation. The negative
+        // result (class absent on this version) is cached too, so this stays a single get afterwards.
+        Optional<Class<?>> cached = cache.get(className);
+        if (cached != null) {
+            return cached;
+        }
 
+        Optional<Class<?>> clazz = resolveClass(className);
+        if (!clazz.isPresent()) {
             for (String alias : aliases) {
-                clazz = resolveClass(alias);
-                if (clazz.isPresent()) {
-                    return clazz;
+                Optional<Class<?>> aliasClazz = resolveClass(alias);
+                if (aliasClazz.isPresent()) {
+                    clazz = aliasClazz;
+                    break;
                 }
             }
+        }
 
-            return Optional.empty();
-        });
+        cache.put(className, clazz);
+        return clazz;
     }
 }


### PR DESCRIPTION
`getPackageClass` uses `cache.computeIfAbsent(className, x -> {...})`. The lambda captures `className`/`aliases`, so a new instance is allocated on every call — including cache hits.

This is per-packet hot: `getPacketType` → `isBundlePacket` → `getPackedBundlePacketClass` → `getPackageClass`. On < 1.19.4 (no bundle packet) every packet hits a cached `Optional.empty()` yet still allocates a lambda — prominent in allocation profiles as `DirectMethodHandle.allocateInstance`.

Fix: get-first fast path, resolve + `put` only on miss. Same behavior, negatives still cached, thread-safe (`ConcurrentHashMap`, benign duplicate resolve on miss).
