### PR TITLE
fix async packet type logic, buffer slicing, and null/out-of-bounds guards

### DIFF
--- a/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
+++ b/src/main/java/com/comphenix/protocol/async/AsyncFilterManager.java
@@ -323,12 +323,12 @@ public class AsyncFilterManager implements AsynchronousManager {
 
     @Override
     public Set<PacketType> getReceivingTypes() {
-        return serverProcessingQueue.keySet();
+        return clientProcessingQueue.keySet();
     }
 
     @Override
     public Set<PacketType> getSendingTypes() {
-        return clientProcessingQueue.keySet();
+        return serverProcessingQueue.keySet();
     }
     
     /**

--- a/src/main/java/com/comphenix/protocol/async/PlayerSendingHandler.java
+++ b/src/main/java/com/comphenix/protocol/async/PlayerSendingHandler.java
@@ -134,14 +134,18 @@ class PlayerSendingHandler {
      * @return The server or client sending queue the packet belongs to.
      */
     public PacketSendingQueue getSendingQueue(PacketEvent packet, boolean createNew) {
-        QueueContainer queues = playerSendingQueues.get(packet.getPlayer());
+        Player player = packet.getPlayer();
+        if (player == null)
+            return null;
+
+        QueueContainer queues = playerSendingQueues.get(player);
         
         // Safe concurrent initialization
         if (queues == null && createNew) {
             final QueueContainer newContainer = new QueueContainer();
 
             // Attempt to map the queue
-            queues = playerSendingQueues.putIfAbsent(packet.getPlayer(), newContainer);
+            queues = playerSendingQueues.putIfAbsent(player, newContainer);
             
             if (queues == null) {
                 queues = newContainer;

--- a/src/main/java/com/comphenix/protocol/collections/IntegerMap.java
+++ b/src/main/java/com/comphenix/protocol/collections/IntegerMap.java
@@ -58,6 +58,7 @@ public class IntegerMap<T> {
      * @return The old associated value, or NULL.
      */
     public T remove(int key) {
+        if (key < 0 || key >= array.length) return null;
         T old = array[key];
         array[key] = null;
 

--- a/src/main/java/com/comphenix/protocol/utility/StreamSerializer.java
+++ b/src/main/java/com/comphenix/protocol/utility/StreamSerializer.java
@@ -326,15 +326,9 @@ public class StreamSerializer {
 
     public byte[] getBytesAndRelease(ByteBuf buf) {
         try {
-            if (buf.hasArray()) {
-                // heap buffer, we can access the array directly
-                return buf.array();
-            } else {
-                // direct buffer, we need to copy the bytes into an array
-                byte[] bytes = new byte[buf.readableBytes()];
-                buf.readBytes(bytes);
-                return bytes;
-            }
+            byte[] bytes = new byte[buf.readableBytes()];
+            buf.readBytes(bytes);
+            return bytes;
         } finally {
             ReferenceCountUtil.safeRelease(buf);
         }


### PR DESCRIPTION
- fixed inverted return values for `getSendingTypes()` and `getReceivingTypes()` in `AsyncFilterManager`
- fixed `StreamSerializer.getBytesAndRelease()` returning un-trimmed backing arrays with trailing capacity bytes
- added missing array boundary checks to `IntegerMap.remove()` to prevent `ArrayIndexOutOfBoundsException`
- added a null check for players in `PlayerSendingHandler.getSendingQueue()` to prevent `NullPointerException` on login/status packets