### PR TITLE
Fix: Java 17 bytecode target on paper module (fixes #3661)

### DIFF
--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
@@ -51,6 +52,12 @@ dependencies {
 paperweight.reobfArtifactConfiguration =
     io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
 
+configurations.matching { it.name == "compileClasspath" || it.name == "runtimeClasspath" || it.name == "testCompileClasspath" || it.name == "testRuntimeClasspath" }.configureEach {
+    attributes {
+        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 25)
+    }
+}
+
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(25))
@@ -78,6 +85,10 @@ tasks {
         testLogging {
             exceptionFormat = TestExceptionFormat.FULL
         }
+    }
+
+    compileJava {
+        options.release.set(17)
     }
 
     shadowJar {


### PR DESCRIPTION
Commit 98856a8b only set compileJava release=17 on the root project. The paper subproject still built PaperPlatformProvider (and everything else under paper/src) with the JDK 25 toolchain and no release cap, producing class file version 69, which crashes servers on Java 17-21 with UnsupportedClassVersionError and disables the plugin on load.

Setting options.release=17 alone breaks :paper:compileClasspath resolution, since paper-api's dev-bundle metadata is published as JVM-25-only; Gradle infers a TargetJvmVersion=17 requirement from the release flag and refuses to resolve it. Pinning compileClasspath/ runtimeClasspath/testCompileClasspath/testRuntimeClasspath to TargetJvmVersion=25 keeps dependency resolution on the JDK 25 toolchain while compileJava still emits Java 17-compatible bytecode.